### PR TITLE
T-022: Fix "TARGET TARGET" typo in fragment_session.xml

### DIFF
--- a/.agents/TASKS.md
+++ b/.agents/TASKS.md
@@ -26,7 +26,7 @@
 | T-003 | `done` | Fix Constant Duplication | [T-003](tasks/T-003-fix-temp-threshold-constant.md) | — |
 | T-004 | `done` | Data Retention / Pruning | [T-004](tasks/T-004-data-retention-pruning.md) | — |
 | T-005 | `done` | targetSdk 35 Compat Pass | [T-005](tasks/T-005-targetsdk35-compat.md) | — |
-| T-022 | `ready` | Fix "TARGET TARGET" Typo | [T-022](tasks/T-022-fix-target-target-typo.md) | — |
+| T-022 | `done` | Fix "TARGET TARGET" Typo | [T-022](tasks/T-022-fix-target-target-typo.md) | — |
 | T-023 | `ready` | Wire Boost Visualization Toggle | [T-023](tasks/T-023-wire-boost-viz-toggle.md) | — |
 | T-024 | `ready` | Wire Factory Reset Button | [T-024](tasks/T-024-wire-factory-reset-button.md) | — |
 | T-025 | `ready` | Fix Day Start Hour Subtitle | [T-025](tasks/T-025-fix-day-start-subtitle.md) | — |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project. Agents: append to the top of the relevant section after completing work.
 
+### 2026-03-24 — T-022: Fix "TARGET TARGET" Typo
+- **Fixed** copy-paste error in `fragment_session.xml` line 398 — changed `android:text="TARGET TARGET"` to `android:text="TARGET TEMP"`
+
 ### 2026-03-24 — Phase 0: Stop the Bleeding
 - **Changed** Room dependency from `2.7.0-alpha13` to `2.6.1` (stable); drop alpha channel
 - **Changed** `targetSdk`/`compileSdk` from 34 to 35 (Play Store requirement)

--- a/app/src/main/res/layout/fragment_session.xml
+++ b/app/src/main/res/layout/fragment_session.xml
@@ -395,7 +395,7 @@
                             <TextView
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
-                                android:text="TARGET TARGET"
+                                android:text="TARGET TEMP"
                                 android:textColor="#FFFFFF"
                                 android:textSize="16sp"
                                 android:textStyle="bold" />


### PR DESCRIPTION
## Summary
- Fixed copy-paste error in `fragment_session.xml` line 398
- Changed `android:text="TARGET TARGET"` to `android:text="TARGET TEMP"`

## Test plan
- [x] Fixed text displays correctly in layout file
- [ ] Visual inspection on device confirms "TARGET TEMP" displays in session screen (verify in CI build)

## Files changed
- `app/src/main/res/layout/fragment_session.xml` — single line fix

https://claude.ai/code/session_01FtNieK5KxQp8s4dptCWQs5