### PR TITLE
T-029 — Persist battery card expand state in ViewModel

### DIFF
--- a/app/src/main/java/com/sbtracker/MainViewModel.kt
+++ b/app/src/main/java/com/sbtracker/MainViewModel.kt
@@ -928,6 +928,15 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
 
     fun setGraphPeriod(p: GraphPeriod) { _graphPeriod.value = p }
 
+    private val _drainCardExpanded  = MutableStateFlow(true)
+    val drainCardExpanded: StateFlow<Boolean> = _drainCardExpanded.asStateFlow()
+
+    private val _healthCardExpanded = MutableStateFlow(false)
+    val healthCardExpanded: StateFlow<Boolean> = _healthCardExpanded.asStateFlow()
+
+    fun toggleDrainCard()  { _drainCardExpanded.value  = !_drainCardExpanded.value }
+    fun toggleHealthCard() { _healthCardExpanded.value = !_healthCardExpanded.value }
+
 
 
     private fun computeGraphWindowStart(period: GraphPeriod, startHour: Int): Long {

--- a/app/src/main/java/com/sbtracker/ui/BatteryFragment.kt
+++ b/app/src/main/java/com/sbtracker/ui/BatteryFragment.kt
@@ -91,25 +91,26 @@ class BatteryFragment : Fragment() {
         val contentDrain = view.findViewById<View>(R.id.content_drain_analysis)
         val headerDrain = view.findViewById<View>(R.id.header_drain_analysis)
         val tvExpandDrain = view.findViewById<TextView>(R.id.tv_expand_drain)
-        var drainExpanded = true
-
-        headerDrain.setOnClickListener {
-            drainExpanded = !drainExpanded
-            contentDrain.visibility = if (drainExpanded) View.VISIBLE else View.GONE
-            tvExpandDrain.text = if (drainExpanded) "▼" else "◀"
-        }
 
         val contentHealth = view.findViewById<View>(R.id.content_charge_health)
         val headerHealth = view.findViewById<View>(R.id.header_charge_health)
         val tvExpandHealth = view.findViewById<TextView>(R.id.tv_expand_health)
-        var healthExpanded = false
-        contentHealth.visibility = View.GONE
-        tvExpandHealth.text = "◀"
 
-        headerHealth.setOnClickListener {
-            healthExpanded = !healthExpanded
-            contentHealth.visibility = if (healthExpanded) View.VISIBLE else View.GONE
-            tvExpandHealth.text = if (healthExpanded) "▼" else "◀"
+        headerDrain.setOnClickListener { vm.toggleDrainCard() }
+        headerHealth.setOnClickListener { vm.toggleHealthCard() }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            vm.drainCardExpanded.collect { expanded ->
+                contentDrain.visibility = if (expanded) View.VISIBLE else View.GONE
+                tvExpandDrain.text = if (expanded) "▼" else "◀"
+            }
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            vm.healthCardExpanded.collect { expanded ->
+                contentHealth.visibility = if (expanded) View.VISIBLE else View.GONE
+                tvExpandHealth.text = if (expanded) "▼" else "◀"
+            }
         }
 
         // Data bindings for Tier 3 Cards


### PR DESCRIPTION
Closes T-029

Moves drain/health card expand state from local fragment vars into `MainViewModel` StateFlows so state survives back-navigation and config changes.