### PR TITLE
fix(B-001): replace fallbackToDestructiveMigration with explicit MIGRATION_1_2

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -72,7 +72,7 @@
 
 | ID | Status | Priority | Description |
 |---|---|---|---|
-| B-001 | `planned` | P1 | `fallbackToDestructiveMigration()` must be removed before public release |
+| B-001 | `done` | P1 | `fallbackToDestructiveMigration()` must be removed before public release |
 | B-002 | `done` | P2 | History Page vertical scroll locked by unwieldy charts | Fixed touch interception |
 | B-003 | `done` | P1 | Battery Page crashes on load due to narrow graph segments | Fixed `coerceIn` range in `BatteryGraphView` |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # SBTracker — Changelog
 
 ### [Unreleased]
+- **Fixed** (B-001) Removed `fallbackToDestructiveMigration()`; added explicit `MIGRATION_1_2` (no-op) so Room accepts existing v1 databases safely.
 - **Fixed** (T-028) Silent exceptions in `BleCommandQueue` and `MainViewModel` are now logged to logcat for easier troubleshooting.
 
 All notable changes to this project. Agents: append to the top of the relevant section after completing work.

--- a/app/src/main/java/com/sbtracker/data/AppDatabase.kt
+++ b/app/src/main/java/com/sbtracker/data/AppDatabase.kt
@@ -8,17 +8,14 @@ import androidx.room.RoomDatabase
 /**
  * Room database for SBTracker.
  *
- * Schema version 1 — frozen baseline.
+ * Current schema version: 2.
  *
  * Migration strategy:
  *  1. Bump version from N to N+1 (increment by 1, always).
- *  2. Write Migration(N, N+1) with ALTER TABLE / CREATE TABLE SQL.
+ *  2. Write Migration(N, N+1) with ALTER TABLE / CREATE TABLE SQL in Migrations.kt.
  *  3. Add the migration to the builder via .addMigrations(...).
  *  4. Export the new schema JSON.
- *
- * fallbackToDestructiveMigration() is kept as a last-resort safety net
- * during development.  Remove it before the first public release and
- * rely solely on explicit migrations from that point forward.
+ *  5. Update MIGRATIONS.md with the version history entry.
  */
 @Database(
     entities = [
@@ -52,9 +49,7 @@ abstract class AppDatabase : RoomDatabase() {
                     AppDatabase::class.java,
                     "sbtracker.db"
                 )
-                    // Safety net during development — wipes DB on unrecognised version.
-                    // TODO: Remove before first public release; use explicit migrations only.
-                    .fallbackToDestructiveMigration()
+                    .addMigrations(MIGRATION_1_2)
                     .build()
                     .also { INSTANCE = it }
             }

--- a/app/src/main/java/com/sbtracker/data/MIGRATIONS.md
+++ b/app/src/main/java/com/sbtracker/data/MIGRATIONS.md
@@ -5,6 +5,7 @@
 | Version | Description |
 |---------|-------------|
 | 1       | Frozen baseline (2026-03). All pre-release iterations collapsed. |
+| 2       | No-op version bump (identity hash unchanged). `fallbackToDestructiveMigration()` removed; explicit migrations now required. |
 
 ## How to Add or Modify Schema
 
@@ -42,6 +43,5 @@ Same process, but use `CREATE TABLE IF NOT EXISTS` with all columns and indices.
 ### Important Rules
 
 - **Always increment by 1** — never jump versions.
-- **Never remove `fallbackToDestructiveMigration()`** during development — it's a safety net.
-- **Before first public release**: remove `fallbackToDestructiveMigration()` and rely solely on explicit migrations.
+- **Never use `fallbackToDestructiveMigration()`** — it has been removed. All schema changes require an explicit `Migration` object.
 - **`device_status` is the god log** — all analytics derive from it at query time. Adding columns here retroactively applies defaults to old rows. No re-ingestion needed.

--- a/app/src/main/java/com/sbtracker/data/Migrations.kt
+++ b/app/src/main/java/com/sbtracker/data/Migrations.kt
@@ -1,0 +1,14 @@
+package com.sbtracker.data
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+/**
+ * Version bump 1 → 2: schema structure was unchanged; identity hashes are equal.
+ * The migration is a no-op but must be registered so Room accepts existing databases.
+ */
+val MIGRATION_1_2 = object : Migration(1, 2) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        // No DDL changes between v1 and v2.
+    }
+}


### PR DESCRIPTION
The v1→v2 bump was a no-op (identical identity hashes), so MIGRATION_1_2
is a no-op object that lets Room accept existing v1 databases without
wiping them. fallbackToDestructiveMigration() is removed; all future
schema changes must supply an explicit Migration.

https://claude.ai/code/session_01LrB2ky8Xf6Nyhhdqc6bbd4