### PR TITLE
Fix compilation and extract colors.xml

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
-    id 'kotlin-kapt'
+    id 'com.google.devtools.ksp'
     id 'com.google.dagger.hilt.android'
 }
 
@@ -15,12 +15,6 @@ android {
         targetSdk 35
         versionCode 1
         versionName "1.0"
-
-        javaCompileOptions {
-            annotationProcessorOptions {
-                arguments += ["room.schemaLocation": "$projectDir/schemas".toString()]
-            }
-        }
     }
 
     buildTypes {
@@ -49,18 +43,16 @@ kotlin {
     jvmToolchain(21)
 }
 
-kapt {
-    arguments {
-        arg("room.schemaLocation", "$projectDir/schemas")
-    }
+ksp {
+    arg("room.schemaLocation", "$projectDir/schemas")
 }
 
 dependencies {
     // Room
-    def room_version = "2.6.1"
+    def room_version = "2.8.4"
     implementation "androidx.room:room-runtime:$room_version"
     implementation "androidx.room:room-ktx:$room_version"
-    kapt "androidx.room:room-compiler:$room_version"
+    ksp "androidx.room:room-compiler:$room_version"
 
     // Lifecycle / ViewModel
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.8.7'
@@ -78,8 +70,6 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
 
     // Hilt
-    implementation "com.google.dagger:hilt-android:2.51.1"
-    kapt "com.google.dagger:hilt-compiler:2.51.1"
-    // For ViewModel injection if needed (older versions needed hilt-lifecycle-viewmodel)
-    // In recent Hilt, @HiltViewModel is in hilt-android.
+    implementation "com.google.dagger:hilt-android:2.59.2"
+    ksp "com.google.dagger:hilt-compiler:2.59.2"
 }

--- a/app/src/main/java/com/sbtracker/MainViewModel.kt
+++ b/app/src/main/java/com/sbtracker/MainViewModel.kt
@@ -16,6 +16,7 @@ import androidx.core.content.FileProvider
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.lifecycle.viewModelScope
 import com.sbtracker.analytics.AnalyticsRepository
 import com.sbtracker.data.AppDatabase
@@ -26,7 +27,6 @@ import com.sbtracker.data.ExtendedData
 import com.sbtracker.data.Hit
 import com.sbtracker.data.Session
 import com.sbtracker.data.SessionSummary
-import com.sbtracker.analytics.AnalyticsRepository
 import com.sbtracker.analytics.BatteryInsights
 import com.sbtracker.analytics.DailyStats
 import com.sbtracker.analytics.HistoryStats

--- a/app/src/main/java/com/sbtracker/data/AppDatabase.kt
+++ b/app/src/main/java/com/sbtracker/data/AppDatabase.kt
@@ -40,6 +40,4 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun sessionDao():      SessionDao
     abstract fun chargeCycleDao():  ChargeCycleDao
     abstract fun hitDao():          HitDao
-
-    abstract fun hitDao():          HitDao
 }

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Primary theme palette -->
+    <color name="color_blue">#0A84FF</color>
+    <color name="color_green">#30D158</color>
+    <color name="color_red">#FF453A</color>
+    <color name="color_yellow">#FFD60A</color>
+    <color name="color_orange">#FF9F0A</color>
+
+    <color name="color_battery_ok">#30D158</color>
+
+    <!-- Grays -->
+    <color name="color_gray_mid">#636366</color>
+    <color name="color_gray_dim">#8E8E93</color>
+    <color name="color_surface">#2C2C2E</color>
+    <color name="color_background">#111113</color>
+
+    <!-- Custom usage colors -->
+    <color name="color_boost_bar_fill">#80A88F</color>
+    <color name="color_heat_overlay_dark">#261905</color>
+    <color name="color_cool_overlay_dark">#091F0D</color>
+
+    <color name="color_tint_orange">#261905</color>
+    <color name="color_tint_green">#091F0D</color>
+</resources>

--- a/build.gradle
+++ b/build.gradle
@@ -2,5 +2,6 @@
 plugins {
     id 'com.android.application' version '9.1.0' apply false
     id 'org.jetbrains.kotlin.android' version '2.2.10' apply false
-    id 'com.google.dagger.hilt.android' version '2.51.1' apply false
+    id 'com.google.dagger.hilt.android' version '2.59.2' apply false
+    id 'com.google.devtools.ksp' version '2.3.6' apply false
 }


### PR DESCRIPTION
Migrates KAPT to KSP to resolve Kotlin 2.2 metadata errors, and introduces a centralized colors.xml per T-027.