### PR TITLE
T-037 — Settings: Capsule Weight + Default Pack Type UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - **Fixed** Stabilized reconnection loop to prevent concurrent `connectGatt` collisions.
 
 ### [Unreleased]
+- **Added** (F-018/T-037) Capsule Weight and Default Pack Type settings rows wired to MainViewModel
 - **Added** (F-018/T-034) `capsuleWeightGrams` and `defaultIsCapsule` SharedPrefs-backed StateFlows + setters in `MainViewModel`
 - **Added** (F-048) Implemented an exponential backoff auto-reconnect loop (up to 30s intervals) that runs in the background if the device drops unexpectedly. Includes a 5-minute hard timeout to prevent endless battery drain if the device is permanently out of range.
 - **Added** (F-048) Updated `BleService` persistent notification to reflect active reconnection attempts.

--- a/app/src/main/java/com/sbtracker/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/sbtracker/ui/SettingsFragment.kt
@@ -10,7 +10,9 @@ import android.widget.TextView
 import androidx.appcompat.widget.SwitchCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.sbtracker.*
 import com.sbtracker.databinding.FragmentSettingsBinding
 import dagger.hilt.android.AndroidEntryPoint
@@ -166,6 +168,49 @@ class SettingsFragment : Fragment() {
         }
         viewLifecycleOwner.lifecycleScope.launch {
             vm.firmwareVersion.collect { f -> tvFw.text = "Firmware: ${f ?: "---"}" }
+        }
+
+        val tvDefaultPackType = binding.tvDefaultPackTypeValue
+        val tvCapsuleWeight   = binding.tvCapsuleWeightValue
+
+        // Observe and display current values
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                launch {
+                    vm.defaultIsCapsule.collect { isCapsule ->
+                        tvDefaultPackType.text = if (isCapsule) "Capsule" else "Free Pack"
+                    }
+                }
+                launch {
+                    vm.capsuleWeightGrams.collect { grams ->
+                        tvCapsuleWeight.text = "%.2f g".format(grams)
+                    }
+                }
+            }
+        }
+
+        // Click: toggle pack type
+        binding.rowDefaultPackType.setOnClickListener {
+            vm.setDefaultIsCapsule(!vm.defaultIsCapsule.value)
+        }
+
+        // Click: edit capsule weight
+        binding.rowCapsuleWeight.setOnClickListener {
+            val input = android.widget.EditText(requireContext()).apply {
+                inputType = android.text.InputType.TYPE_CLASS_NUMBER or android.text.InputType.TYPE_NUMBER_FLAG_DECIMAL
+                setText("%.2f".format(vm.capsuleWeightGrams.value))
+                selectAll()
+            }
+            android.app.AlertDialog.Builder(requireContext())
+                .setTitle("Capsule Weight (grams)")
+                .setMessage("Enter weight in grams (0.01 – 2.00)")
+                .setView(input)
+                .setPositiveButton("Save") { _, _ ->
+                    val grams = input.text.toString().toFloatOrNull()
+                    if (grams != null) vm.setCapsuleWeight(grams)
+                }
+                .setNegativeButton("Cancel", null)
+                .show()
         }
     }
 }

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -634,5 +634,82 @@
             android:textColor="#FF453A"
             app:cornerRadius="16dp" />
 
+        <!-- HEALTH & DOSAGE -->
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:text="HEALTH &amp; DOSAGE"
+            android:textColor="#80A88F"
+            android:textSize="11sp"
+            android:letterSpacing="0.1"
+            android:textStyle="bold" />
+
+        <androidx.cardview.widget.CardView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            app:cardBackgroundColor="#0B110D"
+            app:cardCornerRadius="20dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:padding="8dp">
+
+                <!-- Default Pack Type row -->
+                <LinearLayout
+                    android:id="@+id/row_default_pack_type"
+                    android:layout_width="match_parent"
+                    android:layout_height="64dp"
+                    android:gravity="center_vertical"
+                    android:paddingHorizontal="16dp"
+                    android:background="?android:attr/selectableItemBackground">
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="Default Pack Type"
+                        android:textColor="#FFFFFF"
+                        android:textSize="16sp" />
+                    <TextView
+                        android:id="@+id/tv_default_pack_type_value"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="Free Pack"
+                        android:textColor="#00FF41"
+                        android:textSize="16sp" />
+                </LinearLayout>
+
+                <View android:layout_width="match_parent" android:layout_height="1dp" android:layout_marginHorizontal="16dp" android:background="#141E17" />
+
+                <!-- Capsule Weight row -->
+                <LinearLayout
+                    android:id="@+id/row_capsule_weight"
+                    android:layout_width="match_parent"
+                    android:layout_height="64dp"
+                    android:gravity="center_vertical"
+                    android:paddingHorizontal="16dp"
+                    android:background="?android:attr/selectableItemBackground">
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="Capsule Weight"
+                        android:textColor="#FFFFFF"
+                        android:textSize="16sp" />
+                    <TextView
+                        android:id="@+id/tv_capsule_weight_value"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="0.10 g"
+                        android:textColor="#00FF41"
+                        android:textSize="16sp" />
+                </LinearLayout>
+
+            </LinearLayout>
+        </androidx.cardview.widget.CardView>
+
     </LinearLayout>
 </androidx.core.widget.NestedScrollView>


### PR DESCRIPTION
Adds a "Health & Dosage" section to the Settings screen with two new preference rows:

- **Default Pack Type** — tap to toggle between Capsule / Free Pack, wired to `vm.setDefaultIsCapsule()`
- **Capsule Weight** — displays current weight (e.g. "0.10 g"), tap opens a number input dialog, wired to `vm.setCapsuleWeight()`

Both rows observe their respective StateFlows from T-034 and update reactively.

**Files changed:** `SettingsFragment.kt`, `fragment_settings.xml`

Closes T-037. Depends on T-034 (merged to dev).