### PR TITLE
T-038 — History: Health & Intake analytics card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 - **Fixed** Stabilized reconnection loop to prevent concurrent `connectGatt` collisions.
 
 ### [Unreleased]
-- **Added** (F-018/T-037) Capsule Weight and Default Pack Type settings rows wired to MainViewModel
+- **Added** (F-018/T-038) Health & Intake analytics card on History screen showing all-time/weekly grams and capsule split
 - **Added** (F-018/T-034) `capsuleWeightGrams` and `defaultIsCapsule` SharedPrefs-backed StateFlows + setters in `MainViewModel`
 - **Added** (F-048) Implemented an exponential backoff auto-reconnect loop (up to 30s intervals) that runs in the background if the device drops unexpectedly. Includes a 5-minute hard timeout to prevent endless battery drain if the device is permanently out of range.
 - **Added** (F-048) Updated `BleService` persistent notification to reflect active reconnection attempts.

--- a/app/src/main/java/com/sbtracker/MainViewModel.kt
+++ b/app/src/main/java/com/sbtracker/MainViewModel.kt
@@ -26,10 +26,12 @@ import com.sbtracker.data.DeviceStatus
 import com.sbtracker.data.ExtendedData
 import com.sbtracker.data.Hit
 import com.sbtracker.data.Session
+import com.sbtracker.data.SessionMetadata
 import com.sbtracker.data.SessionSummary
 import com.sbtracker.analytics.BatteryInsights
 import com.sbtracker.analytics.DailyStats
 import com.sbtracker.analytics.HistoryStats
+import com.sbtracker.analytics.IntakeStats
 import com.sbtracker.analytics.PersonalRecords
 import com.sbtracker.analytics.ProfileStats
 import com.sbtracker.analytics.UsageInsights
@@ -408,6 +410,11 @@ class MainViewModel @Inject constructor(
             withContext(Dispatchers.IO) {
                 runCatching { backcompileSessionsFromLogsIfNeeded() }
             }
+        }
+
+        // Refresh intake stats whenever the active device changes.
+        viewModelScope.launch {
+            _activeDevice.collect { refreshIntakeStats() }
         }
     }
 
@@ -915,6 +922,33 @@ class MainViewModel @Inject constructor(
         combine(deviceSessionSummaries, _dayStartHour) { summaries, startHour ->
             analyticsRepo.computeUsageInsights(summaries, startHour)
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), UsageInsights())
+
+    // ── Intake / dosage analytics ─────────────────────────────────────────────
+
+    private val _intakeStats = MutableStateFlow(IntakeStats())
+    val intakeStats: StateFlow<IntakeStats> = _intakeStats.asStateFlow()
+
+    private suspend fun refreshIntakeStats() {
+        withContext(Dispatchers.IO) {
+            val device = _activeDevice.value ?: return@withContext
+            val serial = device.serialNumber.ifEmpty { null }
+            val address = device.deviceAddress
+            val sessions = db.sessionDao().getRecentSessions(serial ?: "", address, Int.MAX_VALUE)
+            if (sessions.isEmpty()) return@withContext
+            val summaries = sessions.mapNotNull { session ->
+                analyticsRepo.getSessionSummary(session)
+            }
+            val ids = summaries.map { it.id }
+            val metaList = db.sessionMetadataDao().getMetadataForSessions(ids)
+            val metaMap = metaList.associateBy { it.sessionId }
+            val stats = analyticsRepo.computeIntakeStats(
+                summaries,
+                metaMap,
+                _capsuleWeightGrams.value
+            )
+            _intakeStats.value = stats
+        }
+    }
 
     // ── Battery insights — drain trend, charge patterns ───────────────────────
 

--- a/app/src/main/java/com/sbtracker/MainViewModel.kt
+++ b/app/src/main/java/com/sbtracker/MainViewModel.kt
@@ -944,7 +944,8 @@ class MainViewModel @Inject constructor(
             val stats = analyticsRepo.computeIntakeStats(
                 summaries,
                 metaMap,
-                _capsuleWeightGrams.value
+                _capsuleWeightGrams.value,
+                _defaultIsCapsule.value
             )
             _intakeStats.value = stats
         }

--- a/app/src/main/java/com/sbtracker/ui/HistoryFragment.kt
+++ b/app/src/main/java/com/sbtracker/ui/HistoryFragment.kt
@@ -83,6 +83,11 @@ class HistoryFragment : Fragment() {
         val tvSortDrain    = view.findViewById<TextView>(R.id.tv_sort_drain)
         val tvSortTemp     = view.findViewById<TextView>(R.id.tv_sort_temp)
 
+        // ── Health & Intake card ──────────────────────────────────────────────
+        val tvIntakeTotalAll = view.findViewById<TextView>(R.id.tvIntakeTotalAll)
+        val tvIntakeWeek     = view.findViewById<TextView>(R.id.tvIntakeWeek)
+        val tvIntakeSplit    = view.findViewById<TextView>(R.id.tvIntakeSplit)
+
         // Period toggle
         val tvPeriodDay  = view.findViewById<TextView>(R.id.tv_graph_period_day)
         val tvPeriodWeek = view.findViewById<TextView>(R.id.tv_graph_period_week)
@@ -274,6 +279,15 @@ class HistoryFragment : Fragment() {
                 val chartPeriod = if (period == MainViewModel.GraphPeriod.WEEK)
                     HistoryBarChartView.Period.WEEK else HistoryBarChartView.Period.DAY
                 barChart.setData(daily, charges, chartPeriod)
+            }
+        }
+
+        // ── Health & Intake stats ─────────────────────────────────────────────
+        viewLifecycleOwner.lifecycleScope.launch {
+            vm.intakeStats.collect { stats ->
+                tvIntakeTotalAll.text = "%.2fg".format(stats.totalGramsAllTime)
+                tvIntakeWeek.text     = "%.2fg".format(stats.totalGramsThisWeek)
+                tvIntakeSplit.text    = "${stats.capsuleSessionCount}·${stats.freePackSessionCount}"
             }
         }
 

--- a/app/src/main/res/layout/fragment_history.xml
+++ b/app/src/main/res/layout/fragment_history.xml
@@ -639,6 +639,89 @@
         </androidx.cardview.widget.CardView>
 
         <!-- ══════════════════════════════════════════════════════════════════
+             HEALTH & INTAKE ANALYTICS CARD
+             ══════════════════════════════════════════════════════════════════ -->
+        <androidx.cardview.widget.CardView
+            android:id="@+id/cardIntake"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            app:cardCornerRadius="8dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:padding="16dp">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="HEALTH &amp; INTAKE"
+                    android:textAppearance="?attr/textAppearanceCaption" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:layout_marginTop="8dp">
+
+                    <LinearLayout
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:orientation="vertical">
+                        <TextView
+                            android:id="@+id/tvIntakeTotalAll"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="—"
+                            android:textAppearance="?attr/textAppearanceHeadline6" />
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="all time" />
+                    </LinearLayout>
+
+                    <LinearLayout
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:orientation="vertical">
+                        <TextView
+                            android:id="@+id/tvIntakeWeek"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="—"
+                            android:textAppearance="?attr/textAppearanceHeadline6" />
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="this week" />
+                    </LinearLayout>
+
+                    <LinearLayout
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:orientation="vertical">
+                        <TextView
+                            android:id="@+id/tvIntakeSplit"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="—"
+                            android:textAppearance="?attr/textAppearanceHeadline6" />
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="cap · free" />
+                    </LinearLayout>
+
+                </LinearLayout>
+            </LinearLayout>
+        </androidx.cardview.widget.CardView>
+
+        <!-- ══════════════════════════════════════════════════════════════════
              SESSION HISTORY LIST
              ══════════════════════════════════════════════════════════════════ -->
 


### PR DESCRIPTION
Wires computeIntakeStats into MainViewModel and adds a Health & Intake summary card to the History screen. Depends on T-034 and T-035 (both merged). Closes T-038.