### PR TITLE
T-041: Wire enhanced heat-up estimation into SessionFragment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 
 ### [Unreleased]
 - **Added** (F-051/T-040) Enhanced `computeEstimatedHeatUpTime` with time-proximity weighting and temperature-based ETA reductions.
+- **Added** (T-041) Wired context-aware heat-up estimation into `SessionFragment`.
 - **Added** (F-018/T-038) Health & Intake analytics card on History screen showing all-time/weekly grams and capsule split
 - **Added** (F-018/T-034) `capsuleWeightGrams` and `defaultIsCapsule` SharedPrefs-backed StateFlows + setters in `MainViewModel`
 - **Added** (F-048) Implemented an exponential backoff auto-reconnect loop (up to 30s intervals) that runs in the background if the device drops unexpectedly. Includes a 5-minute hard timeout to prevent endless battery drain if the device is permanently out of range.

--- a/app/src/main/java/com/sbtracker/HistoryViewModel.kt
+++ b/app/src/main/java/com/sbtracker/HistoryViewModel.kt
@@ -161,6 +161,32 @@ class HistoryViewModel @Inject constructor(
             if (ms != null) ms / 1000 else null
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
 
+    /** Create a heat-up estimate flow that incorporates time-proximity and device temperature context. */
+    fun estimatedHeatUpTimeSecsWithContext(
+        targetTemp: StateFlow<Int>,
+        bleViewModel: BleViewModel
+    ): StateFlow<Long?> =
+        combine(
+            deviceSessionSummaries,
+            targetTemp,
+            bleViewModel.latestStatus
+        ) { summaries, target, status ->
+            // Calculate time since last session
+            val recentSession = summaries.lastOrNull()
+            val timeSinceLast = if (recentSession != null) {
+                System.currentTimeMillis() - recentSession.endTimeMs
+            } else null
+
+            // Call enhanced estimation with time and temperature parameters
+            val ms = analyticsRepo.computeEstimatedHeatUpTime(
+                targetTempC = target,
+                summaries = summaries,
+                timeSinceLastSessionMs = timeSinceLast,
+                currentDeviceTempC = status?.currentTempC
+            )
+            if (ms != null) ms / 1000 else null
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
+
     // ── Combined history list ──
 
     val sessionHistory: StateFlow<List<HistoryItem>> =

--- a/app/src/main/java/com/sbtracker/ui/SessionFragment.kt
+++ b/app/src/main/java/com/sbtracker/ui/SessionFragment.kt
@@ -142,7 +142,7 @@ class SessionFragment : Fragment() {
         }
 
         viewLifecycleOwner.lifecycleScope.launch {
-            combine(bleVm.latestStatus, historyVm.estimatedHeatUpTimeSecs(bleVm.targetTemp)) { s, est -> s to est }.collect { (s, est) ->
+            combine(bleVm.latestStatus, historyVm.estimatedHeatUpTimeSecsWithContext(bleVm.targetTemp, bleVm)) { s, est -> s to est }.collect { (s, est) ->
                 val isIdleOrOffline = s == null || s.heaterMode == 0
                 if (isIdleOrOffline && est != null) {
                     tvHeatUpEstimate.visibility = View.VISIBLE


### PR DESCRIPTION
Connected the enhanced heat-up estimation logic in AnalyticsRepository to the UI in SessionFragment via HistoryViewModel. Incorporation of time-proximity and current device temperature context is now active during the pre-session state.