### PR TITLE
T-009 & T-010: DataStore Migration + Foundation Unit Tests

### DIFF
--- a/.agents/TASKS.md
+++ b/.agents/TASKS.md
@@ -49,8 +49,8 @@ main  ← stable, merges only from dev
 | T-006 | `done` | Introduce Hilt DI | [T-006](tasks/T-006-introduce-hilt-di.md) | — |
 | T-007 | `done` | Decompose MainViewModel | [T-007](tasks/T-007-decompose-mainviewmodel.md) | — |
 | T-008 | `ready` | Remove Fragment–Activity Casts | [T-008](tasks/T-008-remove-activity-casts.md) | T-007 |
-| T-009 | `ready` | Preferences → DataStore | [T-009](tasks/T-009-preferences-datastore.md) | — |
-| T-010 | `ready` | Unit Tests | [T-010](tasks/T-010-unit-tests.md) | — |
+| T-009 | `done` | Preferences → DataStore | [T-009](tasks/T-009-preferences-datastore.md) | — |
+| T-010 | `done` | Unit Tests | [T-010](tasks/T-010-unit-tests.md) | — |
 | T-026 | `done` | Enable ViewBinding | [T-026](tasks/T-026-enable-viewbinding.md) | — |
 | T-027 | `done` | Extract Hardcoded Colors to colors.xml | [T-027](tasks/T-027-extract-colors-xml.md) | — |
 
@@ -69,10 +69,10 @@ main  ← stable, merges only from dev
 | ID | Status | Title | Task File | Blocked by |
 |---|---|---|---|---|
 | T-011 | `ready` | Session Notes + Rating | [T-011](tasks/T-011-session-notes-rating.md) | T-007 |
-| T-012 | `blocked` | Temperature Presets | [T-012](tasks/T-012-temperature-presets.md) | T-009 |
+| T-012 | `ready` | Temperature Presets | [T-012](tasks/T-012-temperature-presets.md) | T-009 |
 | T-013 | `ready` | History Search & Filtering | [T-013](tasks/T-013-history-filtering.md) | T-007 |
 | T-014 | `ready` | Tolerance Break Tracker | [T-014](tasks/T-014-tolerance-break-tracker.md) | T-007 |
-| T-015 | `blocked` | Onboarding Flow | [T-015](tasks/T-015-onboarding-flow.md) | T-009 |
+| T-015 | `ready` | Onboarding Flow | [T-015](tasks/T-015-onboarding-flow.md) | T-009 |
 | T-030 | `ready` | Migrate to Jetpack Compose | [T-030](tasks/T-030-migrate-to-jetpack-compose.md) | — |
 | T-031 | `done` | Overhaul BLE State Machine | [T-031](tasks/T-031-overhaul-ble-state-machine.md) | — |
 | T-032 | `ready` | Consolidate Multi-Device Analytics | [T-032](tasks/T-032-consolidate-multi-device-analytics.md) | — |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@
 ### [Unreleased]
 - **Added** (F-051/T-040) Enhanced `computeEstimatedHeatUpTime` with time-proximity weighting and temperature-based ETA reductions.
 - **Added** (T-041) Wired context-aware heat-up estimation into `SessionFragment`.
+- **Added** (T-009) Migrated `SharedPreferences` to `Jetpack DataStore` with automated one-time migration.
+- **Added** (T-010) Implemented code-coverage groundwork with unit tests for `HitDetector` and pure analytics in `AnalyticsRepository`.
 - **Added** (F-018/T-038) Health & Intake analytics card on History screen showing all-time/weekly grams and capsule split
 - **Added** (F-018/T-034) `capsuleWeightGrams` and `defaultIsCapsule` SharedPrefs-backed StateFlows + setters in `MainViewModel`
 - **Added** (F-048) Implemented an exponential backoff auto-reconnect loop (up to 30s intervals) that runs in the background if the device drops unexpectedly. Includes a 5-minute hard timeout to prevent endless battery drain if the device is permanently out of range.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -72,4 +72,11 @@ dependencies {
     // Hilt
     implementation "com.google.dagger:hilt-android:2.59.2"
     ksp "com.google.dagger:hilt-compiler:2.59.2"
+
+    // DataStore
+    implementation "androidx.datastore:datastore-preferences:1.1.2"
+
+    // Testing
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.mockito:mockito-core:5.11.0'
 }

--- a/app/src/main/java/com/sbtracker/BatteryViewModel.kt
+++ b/app/src/main/java/com/sbtracker/BatteryViewModel.kt
@@ -28,24 +28,23 @@ import javax.inject.Inject
 class BatteryViewModel @Inject constructor(
     private val db: AppDatabase,
     private val analyticsRepo: AnalyticsRepository,
+    private val prefsRepo: UserPreferencesRepository,
     application: Application
 ) : AndroidViewModel(application) {
 
     private val devicePrefs by lazy {
         getApplication<Application>().getSharedPreferences("known_devices_v1", android.content.Context.MODE_PRIVATE)
     }
-    private val appPrefs by lazy {
-        getApplication<Application>().getSharedPreferences("app_prefs", android.content.Context.MODE_PRIVATE)
-    }
 
     private val _activeDevice = MutableStateFlow<BleViewModel.SavedDevice?>(null)
     val activeDevice: StateFlow<BleViewModel.SavedDevice?> = _activeDevice.asStateFlow()
 
-    private val _dayStartHour = MutableStateFlow(4)
+    private val _dayStartHour = prefsRepo.userPreferencesFlow
+        .map { it.dayStartHour }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 4)
 
     init {
         _activeDevice.value = loadLastDevice()
-        _dayStartHour.value = appPrefs.getInt("day_start_hour", 4)
     }
 
     fun updateActiveDevice(device: BleViewModel.SavedDevice?) {
@@ -53,7 +52,9 @@ class BatteryViewModel @Inject constructor(
     }
 
     fun updateDayStartHour(hour: Int) {
-        _dayStartHour.value = hour
+        viewModelScope.launch {
+            prefsRepo.updateDayStartHour(hour)
+        }
     }
 
     // ── Device session summaries ──

--- a/app/src/main/java/com/sbtracker/BleViewModel.kt
+++ b/app/src/main/java/com/sbtracker/BleViewModel.kt
@@ -41,6 +41,7 @@ class BleViewModel @Inject constructor(
     private val bleManager: BleManager,
     private val db: AppDatabase,
     private val analyticsRepo: AnalyticsRepository,
+    private val prefsRepo: UserPreferencesRepository,
     application: Application
 ) : AndroidViewModel(application) {
 
@@ -97,9 +98,6 @@ class BleViewModel @Inject constructor(
     private val trackers = mutableMapOf<String, SessionTracker>()
     private val lastSavedChargeState = mutableMapOf<String, SessionTracker.ChargeState?>()
 
-    private val appPrefs by lazy {
-        getApplication<Application>().getSharedPreferences("app_prefs", Context.MODE_PRIVATE)
-    }
     private val devicePrefs by lazy {
         getApplication<Application>().getSharedPreferences("known_devices_v1", Context.MODE_PRIVATE)
     }
@@ -108,12 +106,14 @@ class BleViewModel @Inject constructor(
     }
 
     // Temperature unit — synced from device status, persisted locally
-    private val _isCelsius = MutableStateFlow(true)
-    val isCelsius: StateFlow<Boolean> = _isCelsius.asStateFlow()
+    val isCelsius: StateFlow<Boolean> = prefsRepo.userPreferencesFlow
+        .map { it.isCelsius }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), true)
 
     // Alerts state
-    private val _phoneAlertsEnabled = MutableStateFlow(true)
-    val phoneAlertsEnabled: StateFlow<Boolean> = _phoneAlertsEnabled.asStateFlow()
+    val phoneAlertsEnabled: StateFlow<Boolean> = prefsRepo.userPreferencesFlow
+        .map { it.phoneAlertsEnabled }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), true)
 
     private var lastSetpointReached = false
     private var lastCharge80Reached = false
@@ -122,19 +122,22 @@ class BleViewModel @Inject constructor(
     private var hasSyncedInitialTemp = false
 
     // Dim-on-charge state
-    private val _dimOnChargeEnabled = MutableStateFlow(false)
-    val dimOnChargeEnabled: StateFlow<Boolean> = _dimOnChargeEnabled.asStateFlow()
-    private var wasCharging = false
+    val dimOnChargeEnabled: StateFlow<Boolean> = prefsRepo.userPreferencesFlow
+        .map { it.dimOnChargeEnabled }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
+
     private var preDimBrightness = -1
+    private var wasCharging = false
 
     private val notificationManager = application.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
     private val CHANNEL_ID = "device_alerts"
 
     init {
-        _phoneAlertsEnabled.value = appPrefs.getBoolean("phone_alerts", true)
-        _dimOnChargeEnabled.value = appPrefs.getBoolean("dim_on_charge", false)
-        _isCelsius.value = appPrefs.getBoolean("is_celsius", true)
-        preDimBrightness = appPrefs.getInt("pre_dim_brightness", -1)
+        viewModelScope.launch {
+            prefsRepo.userPreferencesFlow.collect { prefs ->
+                preDimBrightness = prefs.preDimBrightness
+            }
+        }
 
         _activeDevice.value = loadLastDevice()
         _knownDevices.value = loadAllKnownDevices()
@@ -161,9 +164,10 @@ class BleViewModel @Inject constructor(
                 checkAlerts(status)
                 checkChargeDim(status)
 
-                if (status.isCelsius != _isCelsius.value) {
-                    _isCelsius.value = status.isCelsius
-                    appPrefs.edit().putBoolean("is_celsius", status.isCelsius).apply()
+                if (status.isCelsius != isCelsius.value) {
+                    viewModelScope.launch {
+                        prefsRepo.updateIsCelsius(status.isCelsius)
+                    }
                 }
 
                 statusTick++
@@ -340,8 +344,9 @@ class BleViewModel @Inject constructor(
         val s = _latestStatus.value ?: return
         bleManager.sendWrite(BlePacket.buildSetUnit(s.isCelsius))
         val newCelsius = !s.isCelsius
-        _isCelsius.value = newCelsius
-        appPrefs.edit().putBoolean("is_celsius", newCelsius).apply()
+        viewModelScope.launch {
+            prefsRepo.updateIsCelsius(newCelsius)
+        }
     }
 
     // ── Display settings local update ──
@@ -361,13 +366,13 @@ class BleViewModel @Inject constructor(
     // ── Alerts ──
 
     fun togglePhoneAlerts() {
-        val next = !_phoneAlertsEnabled.value
-        _phoneAlertsEnabled.value = next
-        appPrefs.edit().putBoolean("phone_alerts", next).apply()
+        viewModelScope.launch {
+            prefsRepo.updatePhoneAlerts(!phoneAlertsEnabled.value)
+        }
     }
 
     private fun checkAlerts(s: DeviceStatus) {
-        if (!_phoneAlertsEnabled.value) return
+        if (!phoneAlertsEnabled.value) return
         if (s.heaterMode > 0) {
             if (s.setpointReached && !lastSetpointReached) {
                 triggerAlert("Device Ready", "Target temperature reached!")
@@ -443,27 +448,32 @@ class BleViewModel @Inject constructor(
     // ── Dim-on-charge ──
 
     fun toggleDimOnCharge() {
-        val next = !_dimOnChargeEnabled.value
-        _dimOnChargeEnabled.value = next
-        appPrefs.edit().putBoolean("dim_on_charge", next).apply()
+        val next = !dimOnChargeEnabled.value
+        viewModelScope.launch {
+            prefsRepo.updateDimOnCharge(next)
+        }
         if (next && _latestStatus.value?.isCharging == true) {
             val current = _displaySettings.value?.brightness ?: -1
             if (current > 1) {
                 preDimBrightness = current
-                appPrefs.edit().putInt("pre_dim_brightness", current).apply()
+                viewModelScope.launch {
+                    prefsRepo.updatePreDimBrightness(current)
+                }
                 applyBrightnessAndRefresh(1)
             }
         } else if (!next && _latestStatus.value?.isCharging == true) {
             if (preDimBrightness > 1) {
                 applyBrightnessAndRefresh(preDimBrightness)
                 preDimBrightness = -1
-                appPrefs.edit().putInt("pre_dim_brightness", -1).apply()
+                viewModelScope.launch {
+                    prefsRepo.updatePreDimBrightness(-1)
+                }
             }
         }
     }
 
     private fun checkChargeDim(s: DeviceStatus) {
-        if (!_dimOnChargeEnabled.value) {
+        if (!dimOnChargeEnabled.value) {
             wasCharging = s.isCharging
             return
         }
@@ -471,14 +481,18 @@ class BleViewModel @Inject constructor(
             val current = _displaySettings.value?.brightness ?: -1
             if (current > 1) {
                 preDimBrightness = current
-                appPrefs.edit().putInt("pre_dim_brightness", current).apply()
+                viewModelScope.launch {
+                    prefsRepo.updatePreDimBrightness(current)
+                }
                 applyBrightnessAndRefresh(1)
             }
         } else if (!s.isCharging && wasCharging) {
             if (preDimBrightness > 1) {
                 applyBrightnessAndRefresh(preDimBrightness)
                 preDimBrightness = -1
-                appPrefs.edit().putInt("pre_dim_brightness", -1).apply()
+                viewModelScope.launch {
+                    prefsRepo.updatePreDimBrightness(-1)
+                }
             }
         }
         wasCharging = s.isCharging
@@ -493,9 +507,11 @@ class BleViewModel @Inject constructor(
 
     /** Handle manual brightness override during dim-on-charge state. */
     fun onManualBrightnessChange(level: Int) {
-        if (_dimOnChargeEnabled.value && _latestStatus.value?.isCharging == true) {
+        if (dimOnChargeEnabled.value && _latestStatus.value?.isCharging == true) {
             preDimBrightness = level
-            appPrefs.edit().putInt("pre_dim_brightness", level).apply()
+            viewModelScope.launch {
+                prefsRepo.updatePreDimBrightness(level)
+            }
         }
     }
 

--- a/app/src/main/java/com/sbtracker/HistoryViewModel.kt
+++ b/app/src/main/java/com/sbtracker/HistoryViewModel.kt
@@ -47,6 +47,7 @@ import javax.inject.Inject
 class HistoryViewModel @Inject constructor(
     private val db: AppDatabase,
     val analyticsRepo: AnalyticsRepository,
+    private val prefsRepo: UserPreferencesRepository,
     application: Application
 ) : AndroidViewModel(application) {
 
@@ -65,9 +66,6 @@ class HistoryViewModel @Inject constructor(
     fun setSessionFilter(filter: String?) { _sessionFilter.value = filter }
 
     // Active device — loaded from SharedPrefs so we don't depend on BleViewModel
-    private val appPrefs by lazy {
-        getApplication<Application>().getSharedPreferences("app_prefs", android.content.Context.MODE_PRIVATE)
-    }
     private val devicePrefs by lazy {
         getApplication<Application>().getSharedPreferences("known_devices_v1", android.content.Context.MODE_PRIVATE)
     }
@@ -75,15 +73,15 @@ class HistoryViewModel @Inject constructor(
     private val _activeDevice = MutableStateFlow<BleViewModel.SavedDevice?>(null)
     val activeDevice: StateFlow<BleViewModel.SavedDevice?> = _activeDevice.asStateFlow()
 
-    private val _dayStartHour = MutableStateFlow(4)
-    val dayStartHour: StateFlow<Int> = _dayStartHour.asStateFlow()
+    val dayStartHour: StateFlow<Int> = prefsRepo.userPreferencesFlow
+        .map { it.dayStartHour }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 4)
 
     private val _exportUri = MutableSharedFlow<Uri>(extraBufferCapacity = 1)
     val exportUri = _exportUri.asSharedFlow()
 
     init {
         _activeDevice.value = loadLastDevice()
-        _dayStartHour.value = appPrefs.getInt("day_start_hour", 4)
     }
 
     /** Called by fragments when activeDevice changes in BleViewModel. */
@@ -92,7 +90,9 @@ class HistoryViewModel @Inject constructor(
     }
 
     fun updateDayStartHour(hour: Int) {
-        _dayStartHour.value = hour
+        viewModelScope.launch {
+            prefsRepo.updateDayStartHour(hour)
+        }
     }
 
     // ── Raw queries ──

--- a/app/src/main/java/com/sbtracker/SessionReportActivity.kt
+++ b/app/src/main/java/com/sbtracker/SessionReportActivity.kt
@@ -9,7 +9,9 @@ import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import com.sbtracker.data.AppDatabase
+import com.sbtracker.data.UserPreferencesRepository
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.text.SimpleDateFormat
@@ -27,21 +29,24 @@ import java.util.Locale
 class SessionReportActivity : AppCompatActivity() {
 
     @Inject lateinit var db: AppDatabase
+    @Inject lateinit var prefsRepo: UserPreferencesRepository
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_session_report)
 
         val sessionId = intent.getLongExtra("session_id", -1L)
-        val isCelsius = getSharedPreferences("app_prefs", MODE_PRIVATE)
-            .getBoolean("is_celsius", true)
-
+        // We observe the flow but since we only need it once for the report, 
+        // we can just use the first value or collect in lifecycleScope.
+        
         val hitLogView  = findViewById<TextView>(R.id.report_tv_hit_log)
         val graph       = findViewById<SessionGraphView>(R.id.report_graph)
         val btnCapsule  = findViewById<Button>(R.id.report_btn_capsule)
         val btnFreePack = findViewById<Button>(R.id.report_btn_free_pack)
 
         lifecycleScope.launch {
+            val prefs = prefsRepo.userPreferencesFlow.first()
+            val isCelsius = prefs.isCelsius
 
             val session = withContext(Dispatchers.IO) { db.sessionDao().getById(sessionId) }
             if (session == null) {

--- a/app/src/main/java/com/sbtracker/SettingsViewModel.kt
+++ b/app/src/main/java/com/sbtracker/SettingsViewModel.kt
@@ -6,11 +6,12 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.sbtracker.analytics.AnalyticsRepository
 import com.sbtracker.data.AppDatabase
+import com.sbtracker.data.UserPreferencesRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -22,55 +23,55 @@ import javax.inject.Inject
 class SettingsViewModel @Inject constructor(
     private val db: AppDatabase,
     private val analyticsRepo: AnalyticsRepository,
+    private val prefsRepo: UserPreferencesRepository,
     application: Application
 ) : AndroidViewModel(application) {
 
-    private val appPrefs by lazy {
-        getApplication<Application>().getSharedPreferences("app_prefs", Context.MODE_PRIVATE)
-    }
+    val dayStartHour: StateFlow<Int> = prefsRepo.userPreferencesFlow
+        .map { it.dayStartHour }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 4)
 
-    private val _dayStartHour = MutableStateFlow(4)
-    val dayStartHour: StateFlow<Int> = _dayStartHour.asStateFlow()
+    val retentionDays: StateFlow<Int> = prefsRepo.userPreferencesFlow
+        .map { it.retentionDays }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 90)
 
-    private val _retentionDays = MutableStateFlow(90)
-    val retentionDays: StateFlow<Int> = _retentionDays.asStateFlow()
+    val capsuleWeightGrams: StateFlow<Float> = prefsRepo.userPreferencesFlow
+        .map { it.capsuleWeightGrams }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 0.10f)
 
-    private val _capsuleWeightGrams = MutableStateFlow(0.10f)
-    val capsuleWeightGrams: StateFlow<Float> = _capsuleWeightGrams.asStateFlow()
-
-    private val _defaultIsCapsule = MutableStateFlow(false)
-    val defaultIsCapsule: StateFlow<Boolean> = _defaultIsCapsule.asStateFlow()
+    val defaultIsCapsule: StateFlow<Boolean> = prefsRepo.userPreferencesFlow
+        .map { it.defaultIsCapsule }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
 
     init {
-        _dayStartHour.value = appPrefs.getInt("day_start_hour", 4)
-        _retentionDays.value = appPrefs.getInt("retention_days", 90)
-        _capsuleWeightGrams.value = appPrefs.getFloat("capsule_weight_grams", 0.10f)
-        _defaultIsCapsule.value = appPrefs.getBoolean("default_is_capsule", false)
-
         viewModelScope.launch {
-            analyticsRepo.pruneOldData(_retentionDays.value)
+            prefsRepo.userPreferencesFlow.collect { prefs ->
+                analyticsRepo.pruneOldData(prefs.retentionDays)
+            }
         }
     }
 
     fun setDayStartHour(hour: Int) {
-        val next = hour.coerceIn(0, 23)
-        _dayStartHour.value = next
-        appPrefs.edit().putInt("day_start_hour", next).apply()
+        viewModelScope.launch {
+            prefsRepo.updateDayStartHour(hour.coerceIn(0, 23))
+        }
     }
 
     fun setRetentionDays(days: Int) {
-        _retentionDays.value = days
-        appPrefs.edit().putInt("retention_days", days).apply()
+        viewModelScope.launch {
+            prefsRepo.updateRetentionDays(days)
+        }
     }
 
     fun setCapsuleWeight(grams: Float) {
-        val clamped = grams.coerceIn(0.01f, 2.00f)
-        _capsuleWeightGrams.value = clamped
-        appPrefs.edit().putFloat("capsule_weight_grams", clamped).apply()
+        viewModelScope.launch {
+            prefsRepo.updateCapsuleWeight(grams.coerceIn(0.01f, 2.00f))
+        }
     }
 
     fun setDefaultIsCapsule(isCapsule: Boolean) {
-        _defaultIsCapsule.value = isCapsule
-        appPrefs.edit().putBoolean("default_is_capsule", isCapsule).apply()
+        viewModelScope.launch {
+            prefsRepo.updateDefaultIsCapsule(isCapsule)
+        }
     }
 }

--- a/app/src/main/java/com/sbtracker/data/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/sbtracker/data/UserPreferencesRepository.kt
@@ -1,0 +1,130 @@
+package com.sbtracker.data
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.SharedPreferencesMigration
+import androidx.datastore.preferences.core.*
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private const val USER_PREFERENCES = "user_preferences"
+private const val APP_PREFS = "app_prefs"
+
+private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(
+    name = USER_PREFERENCES,
+    produceMigrations = { context ->
+        listOf(SharedPreferencesMigration(context, APP_PREFS))
+    }
+)
+
+@Singleton
+class UserPreferencesRepository @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    private val dataStore = context.dataStore
+
+    private object PreferencesKeys {
+        val DAY_START_HOUR = intPreferencesKey("day_start_hour")
+        val PHONE_ALERTS = booleanPreferencesKey("phone_alerts")
+        val DIM_ON_CHARGE = booleanPreferencesKey("dim_on_charge")
+        val IS_CELSIUS = booleanPreferencesKey("is_celsius")
+        val PRE_DIM_BRIGHTNESS = intPreferencesKey("pre_dim_brightness")
+        val RETENTION_DAYS = intPreferencesKey("retention_days")
+        val CAPSULE_WEIGHT_GRAMS = floatPreferencesKey("capsule_weight_grams")
+        val DEFAULT_IS_CAPSULE = booleanPreferencesKey("default_is_capsule")
+        val TARGET_TEMP = intPreferencesKey("target_temp")
+    }
+
+    val userPreferencesFlow: Flow<UserPreferences> = dataStore.data
+        .catch { exception ->
+            if (exception is IOException) {
+                emit(emptyPreferences())
+            } else {
+                throw exception
+            }
+        }.map { preferences ->
+            UserPreferences(
+                dayStartHour = preferences[PreferencesKeys.DAY_START_HOUR] ?: 4,
+                phoneAlertsEnabled = preferences[PreferencesKeys.PHONE_ALERTS] ?: true,
+                dimOnChargeEnabled = preferences[PreferencesKeys.DIM_ON_CHARGE] ?: false,
+                isCelsius = preferences[PreferencesKeys.IS_CELSIUS] ?: true,
+                preDimBrightness = preferences[PreferencesKeys.PRE_DIM_BRIGHTNESS] ?: -1,
+                retentionDays = preferences[PreferencesKeys.RETENTION_DAYS] ?: 90,
+                capsuleWeightGrams = preferences[PreferencesKeys.CAPSULE_WEIGHT_GRAMS] ?: 0.10f,
+                defaultIsCapsule = preferences[PreferencesKeys.DEFAULT_IS_CAPSULE] ?: false,
+                targetTemp = preferences[PreferencesKeys.TARGET_TEMP] ?: 180
+            )
+        }
+
+    suspend fun updateDayStartHour(hour: Int) {
+        dataStore.edit { preferences ->
+            preferences[PreferencesKeys.DAY_START_HOUR] = hour
+        }
+    }
+
+    suspend fun updatePhoneAlerts(enabled: Boolean) {
+        dataStore.edit { preferences ->
+            preferences[PreferencesKeys.PHONE_ALERTS] = enabled
+        }
+    }
+
+    suspend fun updateDimOnCharge(enabled: Boolean) {
+        dataStore.edit { preferences ->
+            preferences[PreferencesKeys.DIM_ON_CHARGE] = enabled
+        }
+    }
+
+    suspend fun updateIsCelsius(isCelsius: Boolean) {
+        dataStore.edit { preferences ->
+            preferences[PreferencesKeys.IS_CELSIUS] = isCelsius
+        }
+    }
+
+    suspend fun updatePreDimBrightness(brightness: Int) {
+        dataStore.edit { preferences ->
+            preferences[PreferencesKeys.PRE_DIM_BRIGHTNESS] = brightness
+        }
+    }
+
+    suspend fun updateRetentionDays(days: Int) {
+        dataStore.edit { preferences ->
+            preferences[PreferencesKeys.RETENTION_DAYS] = days
+        }
+    }
+
+    suspend fun updateCapsuleWeight(grams: Float) {
+        dataStore.edit { preferences ->
+            preferences[PreferencesKeys.CAPSULE_WEIGHT_GRAMS] = grams
+        }
+    }
+
+    suspend fun updateDefaultIsCapsule(isCapsule: Boolean) {
+        dataStore.edit { preferences ->
+            preferences[PreferencesKeys.DEFAULT_IS_CAPSULE] = isCapsule
+        }
+    }
+
+    suspend fun updateTargetTemp(temp: Int) {
+        dataStore.edit { preferences ->
+            preferences[PreferencesKeys.TARGET_TEMP] = temp
+        }
+    }
+}
+
+data class UserPreferences(
+    val dayStartHour: Int,
+    val phoneAlertsEnabled: Boolean,
+    val dimOnChargeEnabled: Boolean,
+    val isCelsius: Boolean,
+    val preDimBrightness: Int,
+    val retentionDays: Int,
+    val capsuleWeightGrams: Float,
+    val defaultIsCapsule: Boolean,
+    val targetTemp: Int
+)

--- a/app/src/test/java/com/sbtracker/HitDetectorTest.kt
+++ b/app/src/test/java/com/sbtracker/HitDetectorTest.kt
@@ -1,0 +1,106 @@
+package com.sbtracker
+
+import com.sbtracker.data.DeviceStatus
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HitDetectorTest {
+
+    private fun createStatus(
+        timestampMs: Long,
+        heaterMode: Int = 1,
+        setpointReached: Boolean = true,
+        autoShutdownSeconds: Int = 120,
+        currentTempC: Int = 180,
+        targetTempC: Int = 180
+    ) = DeviceStatus(
+        timestampMs = timestampMs,
+        deviceAddress = "AA:BB:CC:DD:EE:FF",
+        deviceType = "Venty",
+        currentTempC = currentTempC,
+        targetTempC = targetTempC,
+        boostOffsetC = 0,
+        superBoostOffsetC = 0,
+        batteryLevel = 100,
+        heaterMode = heaterMode,
+        isCharging = false,
+        setpointReached = setpointReached,
+        autoShutdownSeconds = autoShutdownSeconds,
+        isCelsius = true,
+        vibrationEnabled = true,
+        chargeCurrentOptimization = false,
+        chargeVoltageLimit = false,
+        permanentBluetooth = true,
+        boostVisualization = false
+    )
+
+    @Test
+    fun `detects hit from timer reset`() {
+        // Given: a sequence where timer resets from 118 to 120
+        val statuses = listOf(
+            createStatus(1000, autoShutdownSeconds = 120),
+            createStatus(2000, autoShutdownSeconds = 119),
+            createStatus(3000, autoShutdownSeconds = 118),
+            createStatus(4000, autoShutdownSeconds = 120), // Hit starts here
+            createStatus(5000, autoShutdownSeconds = 119),
+            createStatus(6000, autoShutdownSeconds = 118)  // Hit ends here
+        )
+
+        // When
+        val hits = HitDetector.detect(statuses)
+
+        // Then
+        assertEquals(1, hits.size)
+        assertEquals(4000L, hits[0].startTimeMs)
+        assertEquals(2000L, hits[0].durationMs) // 6000 - 4000
+    }
+
+    @Test
+    fun `detects hit from temp dip`() {
+        // Given: a sequence where temp dips from 180 to 175 (threshold is usually 2 or 3)
+        // BleConstants.TEMP_DIP_THRESHOLD_C is 2 according to common patterns
+        val statuses = listOf(
+            createStatus(1000, currentTempC = 180),
+            createStatus(2000, currentTempC = 179),
+            createStatus(3000, currentTempC = 175), // Hit starts here (dip >= 2)
+            createStatus(4000, currentTempC = 176),
+            createStatus(5000, currentTempC = 180),
+            createStatus(6000, currentTempC = 180, autoShutdownSeconds = 119) // Hit ends when timer starts counting down and no trigger
+        )
+
+        // When
+        val hits = HitDetector.detect(statuses)
+
+        // Then: Hit starts at 3000 (first status with >= 2 dip)
+        // Hit ends at 6000 (timer starts counting down from 120)
+        assertEquals(1, hits.size)
+        assertEquals(3000L, hits[0].startTimeMs)
+        assertEquals(3000L, hits[0].durationMs)
+    }
+
+    @Test
+    fun `does not detect hit if heater is off`() {
+        val statuses = listOf(
+            createStatus(1000, heaterMode = 0, autoShutdownSeconds = 120),
+            createStatus(2000, heaterMode = 0, autoShutdownSeconds = 120)
+        )
+        val hits = HitDetector.detect(statuses)
+        assertTrue(hits.isEmpty())
+    }
+
+    @Test
+    fun `closes hit if heater turns off`() {
+        val statuses = listOf(
+            createStatus(1000, heaterMode = 1, autoShutdownSeconds = 120),
+            createStatus(2000, heaterMode = 1, autoShutdownSeconds = 118),
+            createStatus(3000, heaterMode = 1, autoShutdownSeconds = 120), // Hit starts
+            createStatus(4000, heaterMode = 1, autoShutdownSeconds = 119),
+            createStatus(5000, heaterMode = 0, autoShutdownSeconds = 119)  // Hit ends
+        )
+        val hits = HitDetector.detect(statuses)
+        assertEquals(1, hits.size)
+        assertEquals(3000L, hits[0].startTimeMs)
+        assertEquals(2000L, hits[0].durationMs)
+    }
+}

--- a/app/src/test/java/com/sbtracker/analytics/AnalyticsRepositoryTest.kt
+++ b/app/src/test/java/com/sbtracker/analytics/AnalyticsRepositoryTest.kt
@@ -1,0 +1,113 @@
+package com.sbtracker.analytics
+
+import com.sbtracker.data.AppDatabase
+import com.sbtracker.data.Session
+import com.sbtracker.data.SessionSummary
+import com.sbtracker.data.SessionMetadata
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mock
+
+class AnalyticsRepositoryTest {
+
+    private lateinit var db: AppDatabase
+    private lateinit var repository: AnalyticsRepository
+
+    @Before
+    fun setup() {
+        db = mock(AppDatabase::class.java)
+        repository = AnalyticsRepository(db)
+    }
+
+    private fun createSummary(
+        id: Long,
+        startTimeMs: Long,
+        durationMs: Long = 300_000L,
+        hitCount: Int = 3,
+        batteryConsumed: Int = 5,
+        peakTempC: Int = 180
+    ): SessionSummary {
+        val session = Session(
+            id = id,
+            deviceAddress = "AA:BB:CC:DD:EE:FF",
+            serialNumber = "VENTY001",
+            startTimeMs = startTimeMs,
+            endTimeMs = startTimeMs + durationMs
+        )
+        return SessionSummary(
+            session = session,
+            hitCount = hitCount,
+            totalHitDurationMs = 60_000L,
+            startBattery = 100,
+            endBattery = 100 - batteryConsumed,
+            avgTempC = 175,
+            peakTempC = peakTempC,
+            heatUpTimeMs = 45_000L,
+            heaterWearMinutes = 5
+        )
+    }
+
+    @Test
+    fun `computeDailyStats groups sessions by day correctly`() {
+        // Monday, March 23, 2026, 10:00 AM (1774260000000 approx for 2026? No, let's use fixed offsets)
+        val day1Ms = 1000000000000L // arbitrary fixed point
+        val day2Ms = day1Ms + 24 * 3600_000L
+
+        val summaries = listOf(
+            createSummary(1, day1Ms + 1000),      // Day 1
+            createSummary(2, day1Ms + 3600_000),  // Day 1
+            createSummary(3, day2Ms + 1000)       // Day 2
+        )
+
+        val dailyStats = repository.computeDailyStats(summaries, 4)
+
+        assertEquals(2, dailyStats.size)
+        assertEquals(2, dailyStats[0].sessionCount) // Day 1
+        assertEquals(1, dailyStats[1].sessionCount) // Day 2
+    }
+
+    @Test
+    fun `computeProfileStats sums totals correctly`() {
+        val summaries = listOf(
+            createSummary(1, 1000, hitCount = 3),
+            createSummary(2, 2000, hitCount = 5)
+        )
+        val stats = repository.computeProfileStats(summaries, 100)
+
+        assertEquals(2, stats.totalSessions)
+        assertEquals(8, stats.totalHits)
+        assertEquals(100, stats.lifetimeHeaterMinutes)
+    }
+
+    @Test
+    fun `computeIntakeStats calculates dosage correctly`() {
+        val day1Ms = System.currentTimeMillis() - 3600_000L // 1 hour ago
+        val s1 = createSummary(1, day1Ms)
+        val s2 = createSummary(2, day1Ms - 1000)
+        
+        val summaries = listOf(s1, s2)
+        val metadataMap = mapOf(
+            1L to SessionMetadata(sessionId = 1, isCapsule = true, capsuleWeightGrams = 0.15f),
+            2L to SessionMetadata(sessionId = 2, isCapsule = false)
+        )
+
+        val stats = repository.computeIntakeStats(summaries, metadataMap, 0.10f, false)
+
+        // Only s1 is a capsule.
+        assertEquals(0.15f, stats.totalGramsAllTime, 0.001f)
+        assertTrue(stats.capsuleCount == 1)
+        assertTrue(stats.freePackCount == 1)
+    }
+
+    @Test
+    fun `computeEstimatedHeatUpTime gives reasonable estimate`() {
+        val s1 = createSummary(1, 1000) // Dummy summary
+        val estimate = repository.computeEstimatedHeatUpTime(180, listOf(s1), 3600_000L, 25)
+        
+        // At 25C, estimating to hit 180C should be some positive value.
+        // The default in the repo is often around 45-90 seconds.
+        assertTrue(estimate != null && estimate > 0)
+    }
+}


### PR DESCRIPTION
Migrated all user preferences to Jetpack DataStore with automated one-time migration from SharedPreferences. Added unit test coverage for HitDetector and AnalyticsRepository pure functions. Unblocks T-012 (Presets) and T-015 (Onboarding).