### PR TITLE
fix: missing UserPreferencesRepository imports for KSP resolution

### DIFF
--- a/app/src/main/java/com/sbtracker/BatteryViewModel.kt
+++ b/app/src/main/java/com/sbtracker/BatteryViewModel.kt
@@ -7,6 +7,7 @@ import com.sbtracker.analytics.AnalyticsRepository
 import com.sbtracker.analytics.BatteryInsights
 import com.sbtracker.analytics.PersonalRecords
 import com.sbtracker.data.AppDatabase
+import com.sbtracker.data.UserPreferencesRepository
 import com.sbtracker.data.ChargeCycle
 import com.sbtracker.data.SessionSummary
 import dagger.hilt.android.lifecycle.HiltViewModel

--- a/app/src/main/java/com/sbtracker/BleViewModel.kt
+++ b/app/src/main/java/com/sbtracker/BleViewModel.kt
@@ -18,6 +18,7 @@ import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.lifecycle.viewModelScope
 import com.sbtracker.analytics.AnalyticsRepository
 import com.sbtracker.data.AppDatabase
+import com.sbtracker.data.UserPreferencesRepository
 import com.sbtracker.data.DeviceInfo
 import com.sbtracker.data.DeviceStatus
 import com.sbtracker.data.ExtendedData

--- a/app/src/main/java/com/sbtracker/HistoryViewModel.kt
+++ b/app/src/main/java/com/sbtracker/HistoryViewModel.kt
@@ -12,6 +12,7 @@ import com.sbtracker.analytics.IntakeStats
 import com.sbtracker.analytics.ProfileStats
 import com.sbtracker.analytics.UsageInsights
 import com.sbtracker.data.AppDatabase
+import com.sbtracker.data.UserPreferencesRepository
 import com.sbtracker.data.ChargeCycle
 import com.sbtracker.data.DeviceStatus
 import com.sbtracker.data.Hit


### PR DESCRIPTION
Resolves regression where Hilt's KSP processor could not resolve the UserPreferencesRepository type in ViewModels due to missing explicit imports. KSP requires these imports for types in different packages even if the IDE sometimes infers them.