### PR TITLE
fix(B-011): BLE UI stuck in offline state after reconnect

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -109,6 +109,7 @@ The current dev codebase (v0.1) is extremely close to a functional Alpha. To off
 | B-008 | `planned` | P3 | Autoshutdown in settings doesnt show full granularity of data |
 | B-009 | `done` | P2 | Dim LED while charging doesnt restore to previous level, and acts funny if LED level is changed manually while charging. |
 | B-010 | `planned` | P2 | Boost offset does not seem correct, or target temp is reporting incorrectly. is effective temp really the best method? |
+| B-011 | `done` | P1 | BLE device stays physically connected but UI remains stuck in offline/reconnecting state — `LandingFragment` `Connected` branch was empty, never hid the offline layout. |
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # SBTracker — Changelog
 
+### 2026-03-24 20:15 — Fix BLE UI Stuck in Offline State After Reconnect (Antigravity)
+- **PR to `dev`** (Origin: Bug report — device connected but UI stays in offline state)
+- **Fixed** (B-011) `LandingFragment` connection state observer had an empty `Connected -> {}` branch — the offline layout was never hidden when transitioning from `Reconnecting → Connected`, leaving the UI stuck showing the offline card even with a live GATT session.
+- **Root cause**: Two independent collectors drive the hero card. The connection state collector handles layout visibility; the status+connection combined collector handles live data. The `Connected` case was empty, so `layoutOffline` remained `VISIBLE` until the first status packet arrived and the second collector ran — a visible race condition on every reconnect.
+- **Fix**: `Connected` branch now immediately sets `layoutOffline = GONE` / `layoutOnline = VISIBLE` so the UI transitions as soon as the connection state changes, independent of when the first status packet arrives.
+
 ### 2026-03-24 20:10 — Fix KSP Resolution Failure (Operator/Apoc)
 - **PR to `dev`** (Origin: KSP build issue)
 - **Fixed** Resolves regression where `UserPreferencesRepository` could not be resolved by Hilt KSP processor in `BleViewModel`, `BatteryViewModel`, and `HistoryViewModel`.

--- a/app/src/main/java/com/sbtracker/BatteryViewModel.kt
+++ b/app/src/main/java/com/sbtracker/BatteryViewModel.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 /**

--- a/app/src/main/java/com/sbtracker/BleViewModel.kt
+++ b/app/src/main/java/com/sbtracker/BleViewModel.kt
@@ -27,8 +27,11 @@ import com.sbtracker.data.Session
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject

--- a/app/src/main/java/com/sbtracker/HistoryViewModel.kt
+++ b/app/src/main/java/com/sbtracker/HistoryViewModel.kt
@@ -221,7 +221,7 @@ class HistoryViewModel @Inject constructor(
     // ── Today summaries ──
 
     val todaySummaries: StateFlow<List<SessionSummary>> =
-        combine(allSessionSummaries, _dayStartHour) { summaries, startHour ->
+        combine(allSessionSummaries, dayStartHour) { summaries, startHour ->
             val c = java.util.Calendar.getInstance()
             if (c.get(java.util.Calendar.HOUR_OF_DAY) < startHour) c.add(java.util.Calendar.DAY_OF_YEAR, -1)
             c.set(java.util.Calendar.HOUR_OF_DAY, startHour)
@@ -246,17 +246,17 @@ class HistoryViewModel @Inject constructor(
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), ProfileStats())
 
     val historyStats: StateFlow<HistoryStats> =
-        combine(sessionSummaries, _dayStartHour) { summaries, startHour ->
+        combine(sessionSummaries, dayStartHour) { summaries, startHour ->
             analyticsRepo.computeHistoryStats(summaries, startHour)
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), HistoryStats())
 
     val usageInsights: StateFlow<UsageInsights> =
-        combine(deviceSessionSummaries, _dayStartHour) { summaries, startHour ->
+        combine(deviceSessionSummaries, dayStartHour) { summaries, startHour ->
             analyticsRepo.computeUsageInsights(summaries, startHour)
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), UsageInsights())
 
     val dailyStats: StateFlow<List<DailyStats>> =
-        combine(deviceSessionSummaries, _dayStartHour) { summaries, startHour ->
+        combine(deviceSessionSummaries, dayStartHour) { summaries, startHour ->
             analyticsRepo.computeDailyStats(summaries, startHour)
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
@@ -281,13 +281,13 @@ class HistoryViewModel @Inject constructor(
         }
     }
 
-    val graphWindowStartMs: StateFlow<Long> = combine(_graphPeriod, _dayStartHour) { period, startHour ->
+    val graphWindowStartMs: StateFlow<Long> = combine(_graphPeriod, dayStartHour) { period, startHour ->
         computeGraphWindowStart(period, startHour)
     }.stateIn(viewModelScope, SharingStarted.Eagerly, computeGraphWindowStart(GraphPeriod.DAY, 4))
 
     @OptIn(ExperimentalCoroutinesApi::class)
     val graphStatuses: StateFlow<List<DeviceStatus>> =
-        combine(_activeDevice, _graphPeriod, _dayStartHour) { device, period, startHour ->
+        combine(_activeDevice, _graphPeriod, dayStartHour) { device, period, startHour ->
             Triple(device, period, startHour)
         }.flatMapLatest { (device, period, startHour) ->
             if (device == null) flowOf(emptyList())

--- a/app/src/main/java/com/sbtracker/ui/LandingFragment.kt
+++ b/app/src/main/java/com/sbtracker/ui/LandingFragment.kt
@@ -144,7 +144,12 @@ class LandingFragment : Fragment() {
                         layoutOffline.visibility = View.VISIBLE
                         layoutOnline.visibility = View.GONE
                     }
-                    is BleManager.ConnectionState.Connected -> {}
+                    is BleManager.ConnectionState.Connected -> {
+                        // Immediately swap to online layout so the UI doesn't stay stuck
+                        // in the offline/reconnecting state while waiting for status data.
+                        layoutOffline.visibility = View.GONE
+                        layoutOnline.visibility = View.VISIBLE
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
Fixes **B-011** — device was physically connected over BLE but the app's hero card remained stuck showing the offline layout.

## Root Cause
`LandingFragment` uses two independent collectors to drive the hero card:
1. **Connection state collector** — responsible for layout visibility (offline/online swap)
2. **Combined collector** (`latestStatus + connectionState`) — responsible for live data content

The `Connected` branch in collector #1 was **empty `{}`**. When the device transitioned `Reconnecting → Connected`, the offline layout was never explicitly hidden. The UI stayed stuck until the first status packet triggered collector #2 — a visible race condition on every reconnect.

## Fix
Added explicit layout swaps to the `Connected` branch in `LandingFragment`:
```kotlin
is BleManager.ConnectionState.Connected -> {
    layoutOffline.visibility = View.GONE
    layoutOnline.visibility = View.VISIBLE
}
```
The UI now transitions to the online view immediately when the connection state changes, independent of when the first status packet arrives.

## Files Changed
- `ui/LandingFragment.kt` — fix: handle `Connected` state in connection observer
- `BleViewModel.kt`, `BatteryViewModel.kt`, `HistoryViewModel.kt` — DataStore migration (from previous session)
- `BACKLOG.md` — B-011 added and marked done
- `CHANGELOG.md` — entry added

## Testing
1. Connect device → confirm hero card shows online state immediately
2. Let device go out of range → confirm reconnecting state shows
3. Bring back in range → confirm UI transitions to online without waiting for first status packet