### PR TITLE
Downgrade Android Gradle plugin and Gradle wrapper versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file — configuration common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '9.1.0' apply false
+    id 'com.android.application' version '7.4.2' apply false
     id 'org.jetbrains.kotlin.android' version '2.2.10' apply false
     id 'com.google.dagger.hilt.android' version '2.59.2' apply false
     id 'com.google.devtools.ksp' version '2.3.6' apply false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Description
Downgrade the Android Gradle plugin from version 9.1.0 to 7.4.2 and the Gradle wrapper from 9.3.1 to 8.5. This change addresses compatibility or stability concerns with the newer versions.

## Linked Issues
Ref: 

## Changes Made
- `build.gradle`: Android Gradle plugin version downgraded from 9.1.0 to 7.4.2
- `gradle/wrapper/gradle-wrapper.properties`: Gradle wrapper version downgraded from 9.3.1 to 8.5

## Verification
- [ ] `./gradlew assembleDebug` passed
- [ ] `./gradlew lintDebug` passed (if applicable)
- [ ] Manual verification performed

## Checklist
- [ ] `PROJECT.md` updated
- [ ] `BACKLOG.md` updated
- [ ] `CHANGELOG.md` updated
- [ ] Branch follows `claude/` or `feature/` convention

https://claude.ai/code/session_01Qf3NGYtDESAG5qRih5NuNB