### PR TITLE
feat(T-047): Hide idle temperature on landing, show charge badge

### DIFF
--- a/app/src/main/java/com/sbtracker/ui/LandingFragment.kt
+++ b/app/src/main/java/com/sbtracker/ui/LandingFragment.kt
@@ -56,6 +56,7 @@ class LandingFragment : Fragment() {
         val btnDisconnect = binding.btnCmdDisconnect
         val tvLiveTemp = binding.tvCmdLiveTemp
         val tvLiveTarget = binding.tvCmdLiveTarget
+        val tvCmdChargeBadge = binding.tvCmdChargeBadge
         val cardHero = binding.cardCmdHero
         val btnHeater = binding.btnCmdHeater
         val tvBtnHeaterText = binding.tvBtnHeaterText
@@ -178,10 +179,17 @@ class LandingFragment : Fragment() {
                 layoutOffline.visibility = View.GONE
                 layoutOnline.visibility = View.VISIBLE
 
-                tvLiveTemp.text = s.currentTempC.toDisplayTemp(celsius).toString()
-                tvLiveTarget.text = "/ ${s.targetTempC.toDisplayTemp(celsius)}${celsius.unitSuffix()}"
-
                 val isOn = s.heaterMode > 0
+
+                // Suppress temp views when heater is OFF
+                tvLiveTemp.visibility = if (isOn) View.VISIBLE else View.GONE
+                tvLiveTarget.visibility = if (isOn) View.VISIBLE else View.GONE
+
+                if (isOn) {
+                    tvLiveTemp.text = s.currentTempC.toDisplayTemp(celsius).toString()
+                    tvLiveTarget.text = "/ ${s.targetTempC.toDisplayTemp(celsius)}${celsius.unitSuffix()}"
+                }
+
                 if (isOn) {
                     tvBtnHeaterText.text = "Stop Heater"
                     tvBtnHeaterText.setTextColor(ContextCompat.getColor(requireContext(), R.color.color_red))
@@ -205,6 +213,9 @@ class LandingFragment : Fragment() {
                     tvLiveStatus.setTextColor(ContextCompat.getColor(requireContext(), R.color.color_gray_mid))
                     cardHero.setCardBackgroundColor(ContextCompat.getColor(requireContext(), R.color.color_background))
                 }
+
+                // Show/hide charge badge based on isCharging
+                tvCmdChargeBadge.visibility = if (s.isCharging) View.VISIBLE else View.GONE
 
                 tvTileBatteryVal.text = "${s.batteryLevel}%"
                 tvTileBatteryVal.setTextColor(if (s.batteryLevel <= 20) ContextCompat.getColor(requireContext(), R.color.color_red) else ContextCompat.getColor(requireContext(), R.color.color_green))

--- a/app/src/main/res/layout/fragment_landing.xml
+++ b/app/src/main/res/layout/fragment_landing.xml
@@ -133,6 +133,19 @@
                         android:padding="4dp"/>
                 </LinearLayout>
 
+                <TextView
+                    android:id="@+id/tvCmdChargeBadge"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="⚡ CHARGING"
+                    android:textSize="11sp"
+                    android:textColor="@color/color_green"
+                    android:visibility="gone"
+                    android:paddingStart="8dp"
+                    android:paddingEnd="8dp"
+                    android:paddingTop="4dp"
+                    android:paddingBottom="4dp" />
+
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"


### PR DESCRIPTION
## Summary
Removes misleading 0°C/32°F temperature display during idle (heaterMode == 0) on landing page and adds charge badge visibility for better charging state clarity.

## Changes
- Modified `fragment_landing.xml`: Added charge badge TextView with styling
- Modified `LandingFragment.kt`: Suppress live temperature visibility when idle, control charge badge visibility based on device charging state

## Related
Part of F-055 (Homepage/Landing Page Redesign)