### PR TITLE
feat(T-076): Add hit classification data model

### DIFF
--- a/app/src/main/java/com/sbtracker/BleConstants.kt
+++ b/app/src/main/java/com/sbtracker/BleConstants.kt
@@ -81,4 +81,7 @@ object BleConstants {
 
     /** Temperature dip (°C) that triggers hit detection. Single source of truth. */
     const val TEMP_DIP_THRESHOLD_C = 2
+
+    /** Minimum hit duration (ms) to classify a hit as a large hit / rip. Tune after real-device validation. */
+    const val LARGE_HIT_DURATION_MS = 3000L
 }

--- a/app/src/main/java/com/sbtracker/analytics/AnalyticsModels.kt
+++ b/app/src/main/java/com/sbtracker/analytics/AnalyticsModels.kt
@@ -160,3 +160,25 @@ data class IntakeStats(
     /** Grams per day averaged over the last 30 days. */
     val gramsPerDay30d: Float = 0f
 )
+
+/**
+ * Per-session hit classification counts derived from the hits table.
+ * Used to power the hit-achievement display on the Analytics tab.
+ *
+ * Classification is time-based: a hit is "large" if its durationMs
+ * exceeds [BleConstants.LARGE_HIT_DURATION_MS].
+ *
+ * This is a framework skeleton — add achievement fields here as needed.
+ */
+data class HitAnalysisSummary(
+    /** Total hits classified across all sessions in scope. */
+    val totalHits: Int = 0,
+    /** Hits whose duration exceeded LARGE_HIT_DURATION_MS. */
+    val largeHitCount: Int = 0,
+    /** Hits whose duration was below LARGE_HIT_DURATION_MS. */
+    val sipCount: Int = 0,
+    /** Highest large-hit count recorded in a single session. */
+    val mostLargeHitsInSession: Int = 0,
+    /** Highest sip count recorded in a single session. */
+    val mostSipsInSession: Int = 0
+)


### PR DESCRIPTION
## Summary
Establishes HitAnalysisSummary data model with fields for hit achievement metrics and adds LARGE_HIT_DURATION_MS constant for time-based hit classification.

## Changes
- Created `BleConstants.kt`: Added `LARGE_HIT_DURATION_MS = 3000L`
- Modified `AnalyticsModels.kt`: Added HitAnalysisSummary data class with fields: totalHits, largeHitCount, sipCount, mostLargeHitsInSession, mostSipsInSession

## Related
Part of F-052 (Analytics Display Refactoring)