### PR TITLE
feat(T-069): Centralize notification channel definitions

### DIFF
--- a/app/src/main/java/com/sbtracker/BleService.kt
+++ b/app/src/main/java/com/sbtracker/BleService.kt
@@ -1,14 +1,12 @@
 package com.sbtracker
 
 import android.app.Notification
-import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.app.Service
 import android.content.Context
 import android.content.Intent
 import android.os.Binder
-import android.os.Build
 import android.os.IBinder
 import androidx.core.app.NotificationCompat
 import dagger.hilt.android.AndroidEntryPoint
@@ -39,7 +37,6 @@ class BleService : Service() {
 
     private var bleViewModel: BleViewModel? = null
 
-    private val CHANNEL_ID = "ble_service_channel"
     private val NOTIFICATION_ID = 101
 
     inner class LocalBinder : Binder() {
@@ -52,7 +49,7 @@ class BleService : Service() {
 
     override fun onCreate() {
         super.onCreate()
-        createNotificationChannel()
+        NotificationChannels.createAllChannels(this)
         startForeground(NOTIFICATION_ID, createNotification())
     }
 
@@ -68,18 +65,6 @@ class BleService : Service() {
         }
     }
 
-    private fun createNotificationChannel() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val serviceChannel = NotificationChannel(
-                CHANNEL_ID,
-                "SB Tracker Service",
-                NotificationManager.IMPORTANCE_LOW
-            )
-            val manager = getSystemService(NotificationManager::class.java)
-            manager.createNotificationChannel(serviceChannel)
-        }
-    }
-
     private fun createNotification(
         statusText: String = "Monitoring device...",
         contentText: String = "Background tracking active"
@@ -90,7 +75,7 @@ class BleService : Service() {
             PendingIntent.FLAG_IMMUTABLE
         )
 
-        return NotificationCompat.Builder(this, CHANNEL_ID)
+        return NotificationCompat.Builder(this, NotificationChannels.STATUS)
             .setContentTitle(statusText)
             .setContentText(contentText)
             .setSmallIcon(R.mipmap.ic_launcher)

--- a/app/src/main/java/com/sbtracker/BleViewModel.kt
+++ b/app/src/main/java/com/sbtracker/BleViewModel.kt
@@ -1,7 +1,6 @@
 package com.sbtracker
 
 import android.app.Application
-import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
@@ -134,7 +133,6 @@ class BleViewModel @Inject constructor(
     private var wasCharging = false
 
     private val notificationManager = application.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-    private val CHANNEL_ID = "device_alerts"
 
     init {
         viewModelScope.launch {
@@ -148,7 +146,6 @@ class BleViewModel @Inject constructor(
 
         viewModelScope.launch { refreshKnownDeviceBatteries() }
 
-        createNotificationChannel()
         setupLifecycleObserver()
 
         // ── BLE data pipeline ──
@@ -418,21 +415,12 @@ class BleViewModel @Inject constructor(
         }
     }
 
-    private fun createNotificationChannel() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val channel = NotificationChannel(CHANNEL_ID, "Device Alerts", NotificationManager.IMPORTANCE_HIGH).apply {
-                description = "Vibrations and notifications for temperature and charging events"
-            }
-            notificationManager.createNotificationChannel(channel)
-        }
-    }
-
     private fun showNotification(title: String, message: String) {
         val intent = Intent(getApplication(), MainActivity::class.java).apply {
             flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
         }
         val pendingIntent = PendingIntent.getActivity(getApplication(), 0, intent, PendingIntent.FLAG_IMMUTABLE)
-        val builder = NotificationCompat.Builder(getApplication(), CHANNEL_ID)
+        val builder = NotificationCompat.Builder(getApplication(), NotificationChannels.ALERTS)
             .setSmallIcon(R.mipmap.ic_launcher)
             .setContentTitle(title)
             .setContentText(message)

--- a/app/src/main/java/com/sbtracker/NotificationChannels.kt
+++ b/app/src/main/java/com/sbtracker/NotificationChannels.kt
@@ -1,0 +1,60 @@
+package com.sbtracker
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.os.Build
+
+/**
+ * Centralized notification channel management for SBTracker.
+ * All notification channels are defined and registered here.
+ */
+object NotificationChannels {
+
+    // Channel IDs
+    const val STATUS = "sb_status"
+    const val ALERTS = "sb_alerts"
+    const val CONTROLS = "sb_controls"
+
+    /**
+     * Creates and registers all notification channels with the system.
+     * Safe to call multiple times (createNotificationChannel is idempotent on Android 8.0+).
+     *
+     * @param context Context used to get NotificationManager
+     */
+    fun createAllChannels(context: Context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+            // Device Status channel — persistent status updates, low importance
+            val statusChannel = NotificationChannel(
+                STATUS,
+                "Device Status",
+                NotificationManager.IMPORTANCE_LOW
+            ).apply {
+                description = "Persistent status notifications for device tracking"
+            }
+            manager.createNotificationChannel(statusChannel)
+
+            // Device Alerts channel — urgent notifications, high importance
+            val alertsChannel = NotificationChannel(
+                ALERTS,
+                "Device Alerts",
+                NotificationManager.IMPORTANCE_HIGH
+            ).apply {
+                description = "Vibrations and notifications for temperature and charging events"
+            }
+            manager.createNotificationChannel(alertsChannel)
+
+            // Quick Controls channel — default importance for interactive controls
+            val controlsChannel = NotificationChannel(
+                CONTROLS,
+                "Quick Controls",
+                NotificationManager.IMPORTANCE_DEFAULT
+            ).apply {
+                description = "Quick action controls from notifications"
+            }
+            manager.createNotificationChannel(controlsChannel)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Centralizes notification channel definitions to prevent duplicates and ensure consistent importance levels across the app.

## Changes
- Created `NotificationChannels.kt`: Singleton with channel ID constants (STATUS, ALERTS, CONTROLS) and createAllChannels() method
- Modified `BleService.kt`: Replaced hardcoded channel ID with NotificationChannels.STATUS
- Modified `BleViewModel.kt`: Replaced hardcoded channel ID with NotificationChannels.ALERTS

## Related
Part of F-050 (Notifications Overhaul)