### PR TITLE
feat(T-075): Add Android 13+ runtime notification permission handling

### DIFF
--- a/app/src/main/java/com/sbtracker/BleViewModel.kt
+++ b/app/src/main/java/com/sbtracker/BleViewModel.kt
@@ -428,6 +428,9 @@ class BleViewModel @Inject constructor(
     }
 
     private fun showNotification(title: String, message: String) {
+        if (!NotificationPermissionHelper.isGranted(getApplication())) {
+            return
+        }
         val intent = Intent(getApplication(), MainActivity::class.java).apply {
             flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
         }

--- a/app/src/main/java/com/sbtracker/MainActivity.kt
+++ b/app/src/main/java/com/sbtracker/MainActivity.kt
@@ -74,6 +74,12 @@ class MainActivity : AppCompatActivity() {
             bleVm.startScan()
         }
 
+    private val requestNotificationPermission =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
+            // Permission granted or denied; allow app to continue
+            // Notification attempts will be gated by NotificationPermissionHelper.isGranted()
+        }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
@@ -115,6 +121,13 @@ class MainActivity : AppCompatActivity() {
         lifecycleScope.launch {
             withContext(Dispatchers.IO) {
                 runCatching { historyVm.rebuildSessionHistoryFromLogs() }
+            }
+        }
+
+        // Request POST_NOTIFICATIONS permission on first run (API 33+)
+        if (Build.VERSION.SDK_INT >= 33) {
+            if (!NotificationPermissionHelper.isGranted(this)) {
+                requestNotificationPermission.launch(Manifest.permission.POST_NOTIFICATIONS)
             }
         }
 

--- a/app/src/main/java/com/sbtracker/NotificationPermissionHelper.kt
+++ b/app/src/main/java/com/sbtracker/NotificationPermissionHelper.kt
@@ -1,0 +1,15 @@
+package com.sbtracker
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.core.content.ContextCompat
+
+object NotificationPermissionHelper {
+    fun isGranted(context: Context): Boolean {
+        return ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.POST_NOTIFICATIONS
+        ) == PackageManager.PERMISSION_GRANTED
+    }
+}

--- a/app/src/main/java/com/sbtracker/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/sbtracker/ui/SettingsFragment.kt
@@ -1,5 +1,7 @@
 package com.sbtracker.ui
 
+import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -62,6 +64,12 @@ class SettingsFragment : Fragment() {
         val tvRetentionValue = binding.tvRetentionValue
 
         binding.rowPhoneAlerts.setOnClickListener { bleVm.togglePhoneAlerts() }
+
+        // Show notification permission disabled indicator if needed (Android 13+)
+        if (Build.VERSION.SDK_INT >= 33) {
+            updateNotificationPermissionStatus()
+        }
+
         binding.rowDimOnCharge.setOnClickListener { bleVm.toggleDimOnCharge() }
         binding.rowDayStartHour.setOnClickListener {
             val hours = Array(24) { i -> if (i == 0) "12 AM" else if (i < 12) "$i AM" else if (i == 12) "12 PM" else "${i - 12} PM" }
@@ -239,5 +247,35 @@ class SettingsFragment : Fragment() {
                 .setNegativeButton("Cancel", null)
                 .show()
         }
+    }
+
+    private fun updateNotificationPermissionStatus() {
+        val isGranted = NotificationPermissionHelper.isGranted(requireContext())
+        if (!isGranted) {
+            // Find and update the subtitle TextView within the row
+            val linearLayout = binding.rowPhoneAlerts.getChildAt(0) as? android.widget.LinearLayout
+            if (linearLayout != null && linearLayout.childCount > 1) {
+                val subtitleView = linearLayout.getChildAt(1) as? TextView
+                if (subtitleView != null) {
+                    subtitleView.text = "Notifications disabled — tap to enable in system settings"
+                    subtitleView.setTextColor(android.graphics.Color.parseColor("#FF6B6B"))
+                }
+            }
+            // Override click listener to open notification settings
+            binding.rowPhoneAlerts.setOnClickListener {
+                openNotificationSettings()
+            }
+        }
+    }
+
+    private fun openNotificationSettings() {
+        val intent = Intent().apply {
+            action = "android.settings.APP_NOTIFICATION_SETTINGS"
+            putExtra("android.provider.extra.APP_PACKAGE", requireContext().packageName)
+            if (Build.VERSION.SDK_INT >= 31) {
+                putExtra("android.provider.extra.CHANNEL_ID", NotificationChannels.ALERTS)
+            }
+        }
+        startActivity(intent)
     }
 }


### PR DESCRIPTION
## Summary
Implements Android 13+ runtime permission handling for POST_NOTIFICATIONS with graceful fallback to silent operation when denied.

## Changes
- Created `NotificationPermissionHelper.kt`: Singleton with isGranted() check
- Modified `MainActivity.kt`: Added ActivityResultLauncher for runtime permission request (API 33+ guard)
- Modified `BleViewModel.kt`: Gated showNotification() behind permission check
- Modified `SettingsFragment.kt`: Added permission status display with disabled indicator

## Related
Part of F-050 (Notifications Overhaul)