### PR TITLE
feat(T-043): Implement ProgramRepository with default preset seeding

### DIFF
--- a/app/src/main/java/com/sbtracker/MainViewModel.kt
+++ b/app/src/main/java/com/sbtracker/MainViewModel.kt
@@ -2,8 +2,11 @@ package com.sbtracker
 
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.sbtracker.data.ProgramRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.launch
 
 /**
  * Thin backward-compatibility shell.
@@ -20,5 +23,12 @@ import javax.inject.Inject
  */
 @HiltViewModel
 class MainViewModel @Inject constructor(
-    application: Application
-) : AndroidViewModel(application)
+    application: Application,
+    private val programRepository: ProgramRepository
+) : AndroidViewModel(application) {
+    init {
+        viewModelScope.launch {
+            programRepository.seedDefaultsIfNeeded()
+        }
+    }
+}

--- a/app/src/main/java/com/sbtracker/analytics/AnalyticsModels.kt
+++ b/app/src/main/java/com/sbtracker/analytics/AnalyticsModels.kt
@@ -160,3 +160,25 @@ data class IntakeStats(
     /** Grams per day averaged over the last 30 days. */
     val gramsPerDay30d: Float = 0f
 )
+
+/**
+ * Per-session hit classification counts derived from the hits table.
+ * Used to power the hit-achievement display on the Analytics tab.
+ *
+ * Classification is time-based: a hit is "large" if its durationMs
+ * exceeds [BleConstants.LARGE_HIT_DURATION_MS].
+ *
+ * This is a framework skeleton — add achievement fields here as needed.
+ */
+data class HitAnalysisSummary(
+    /** Total hits classified across all sessions in scope. */
+    val totalHits: Int = 0,
+    /** Hits whose duration exceeded LARGE_HIT_DURATION_MS. */
+    val largeHitCount: Int = 0,
+    /** Hits whose duration was below LARGE_HIT_DURATION_MS. */
+    val sipCount: Int = 0,
+    /** Highest large-hit count recorded in a single session. */
+    val mostLargeHitsInSession: Int = 0,
+    /** Highest sip count recorded in a single session. */
+    val mostSipsInSession: Int = 0
+)

--- a/app/src/main/java/com/sbtracker/data/AppDatabase.kt
+++ b/app/src/main/java/com/sbtracker/data/AppDatabase.kt
@@ -26,9 +26,10 @@ import androidx.room.RoomDatabase
         Session::class,
         ChargeCycle::class,
         Hit::class,
-        SessionMetadata::class
+        SessionMetadata::class,
+        SessionProgram::class
     ],
-    version      = 3,
+    version      = 4,
     exportSchema = true
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -40,4 +41,5 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun chargeCycleDao():  ChargeCycleDao
     abstract fun hitDao():          HitDao
     abstract fun sessionMetadataDao(): SessionMetadataDao
+    abstract fun sessionProgramDao(): SessionProgramDao
 }

--- a/app/src/main/java/com/sbtracker/data/ProgramRepository.kt
+++ b/app/src/main/java/com/sbtracker/data/ProgramRepository.kt
@@ -1,0 +1,44 @@
+package com.sbtracker.data
+
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.Flow
+
+@Singleton
+class ProgramRepository @Inject constructor(
+    private val dao: SessionProgramDao
+) {
+    val programs: Flow<List<SessionProgram>> = dao.observeAll()
+
+    /** Seed default presets if the table is empty. Call once at app start. */
+    suspend fun seedDefaultsIfNeeded() {
+        if (dao.count() > 0) return
+        val defaults = listOf(
+            SessionProgram(
+                name = "Terpene Optimization",
+                targetTempC = 170,
+                boostStepsJson = "[{\"offsetSec\":0,\"boostC\":0},{\"offsetSec\":60,\"boostC\":5},{\"offsetSec\":120,\"boostC\":10}]",
+                isDefault = true
+            ),
+            SessionProgram(
+                name = "Even Step",
+                targetTempC = 185,
+                boostStepsJson = "[{\"offsetSec\":0,\"boostC\":0},{\"offsetSec\":90,\"boostC\":5},{\"offsetSec\":180,\"boostC\":10}]",
+                isDefault = true
+            ),
+            SessionProgram(
+                name = "Full Heat Max Rip",
+                targetTempC = 210,
+                boostStepsJson = "[{\"offsetSec\":0,\"boostC\":10}]",
+                isDefault = true
+            )
+        )
+        defaults.forEach { dao.insertOrUpdate(it) }
+    }
+
+    suspend fun saveProgram(program: SessionProgram): Long = dao.insertOrUpdate(program)
+
+    suspend fun deleteProgram(id: Long) = dao.deleteUserProgram(id)
+
+    suspend fun getById(id: Long): SessionProgram? = dao.getById(id)
+}

--- a/app/src/main/java/com/sbtracker/data/SessionMetadata.kt
+++ b/app/src/main/java/com/sbtracker/data/SessionMetadata.kt
@@ -21,7 +21,8 @@ data class SessionMetadata(
     @PrimaryKey val sessionId: Long,
     val isCapsule: Boolean = false,
     val capsuleWeightGrams: Float = 0.0f,
-    val notes: String? = null
+    val notes: String? = null,
+    val appliedProgramId: Long? = null
 )
 
 @Dao
@@ -40,4 +41,7 @@ interface SessionMetadataDao {
 
     @Query("SELECT * FROM session_metadata WHERE sessionId IN (:sessionIds)")
     suspend fun getMetadataForSessions(sessionIds: List<Long>): List<SessionMetadata>
+
+    @Query("SELECT * FROM session_metadata WHERE appliedProgramId = :programId")
+    suspend fun getSessionsForProgram(programId: Long): List<SessionMetadata>
 }

--- a/app/src/main/java/com/sbtracker/data/SessionProgram.kt
+++ b/app/src/main/java/com/sbtracker/data/SessionProgram.kt
@@ -1,0 +1,36 @@
+package com.sbtracker.data
+
+import androidx.room.Dao
+import androidx.room.Entity
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.PrimaryKey
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Entity(tableName = "session_programs")
+data class SessionProgram(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val name:           String,
+    val targetTempC:    Int,
+    val boostStepsJson: String = "[]",
+    val isDefault:      Boolean = false
+)
+
+@Dao
+interface SessionProgramDao {
+    @Query("SELECT * FROM session_programs ORDER BY isDefault DESC, id ASC")
+    fun observeAll(): Flow<List<SessionProgram>>
+
+    @Query("SELECT * FROM session_programs WHERE id = :id")
+    suspend fun getById(id: Long): SessionProgram?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertOrUpdate(program: SessionProgram): Long
+
+    @Query("DELETE FROM session_programs WHERE id = :id AND isDefault = 0")
+    suspend fun deleteUserProgram(id: Long)
+
+    @Query("SELECT COUNT(*) FROM session_programs")
+    suspend fun count(): Int
+}

--- a/app/src/main/java/com/sbtracker/di/AppModule.kt
+++ b/app/src/main/java/com/sbtracker/di/AppModule.kt
@@ -100,4 +100,10 @@ object AppModule {
     fun provideAnalyticsRepository(db: AppDatabase): AnalyticsRepository {
         return AnalyticsRepository(db)
     }
+
+    @Provides
+    @Singleton
+    fun provideProgramRepository(dao: SessionProgramDao): ProgramRepository {
+        return ProgramRepository(dao)
+    }
 }

--- a/app/src/main/java/com/sbtracker/di/AppModule.kt
+++ b/app/src/main/java/com/sbtracker/di/AppModule.kt
@@ -40,12 +40,28 @@ object AppModule {
             }
         }
 
+        val MIGRATION_3_4 = object : Migration(3, 4) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `session_programs` (" +
+                            "`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
+                            "`name` TEXT NOT NULL, " +
+                            "`targetTempC` INTEGER NOT NULL, " +
+                            "`boostStepsJson` TEXT NOT NULL, " +
+                            "`isDefault` INTEGER NOT NULL)"
+                )
+                db.execSQL(
+                    "ALTER TABLE `session_metadata` ADD COLUMN `appliedProgramId` INTEGER"
+                )
+            }
+        }
+
         return Room.databaseBuilder(
             context,
             AppDatabase::class.java,
             "sbtracker.db"
         )
-            .addMigrations(MIGRATION_1_2, MIGRATION_2_3)
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4)
             .build()
     }
 
@@ -69,6 +85,9 @@ object AppModule {
 
     @Provides
     fun provideSessionMetadataDao(db: AppDatabase): SessionMetadataDao = db.sessionMetadataDao()
+
+    @Provides
+    fun provideSessionProgramDao(db: AppDatabase): SessionProgramDao = db.sessionProgramDao()
 
     @Provides
     @Singleton


### PR DESCRIPTION
## Summary
Provides CRUD operations for session programs with idempotent default seeding of three preset profiles on app startup.

## Changes
- Created `ProgramRepository.kt`: @Singleton with programs Flow, seedDefaultsIfNeeded(), and CRUD methods
  - Seeds "Terpene Optimization" (170°C), "Even Step" (185°C), "Full Heat Max Rip" (210°C) on first run
- Modified `MainViewModel.kt`: Injected ProgramRepository and called seedDefaultsIfNeeded() at startup

## Related
Part of F-027 (Session Programs/Presets)