### PR TITLE
T-067 — Add startingBattery to SessionStats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # SBTracker — Changelog
 
+### 2026-03-25 12:00 — T-067: Add startingBattery to SessionStats (Apoc/Worker)
+
+- **Origin**: Branch `claude/T-067-session-stats-starting-battery` → PR to `dev`
+- **Task**: T-067 (`ready` → `done`)
+- **Changes**:
+  - Added `startingBattery: Int = 0` field to `SessionStats` data class in `SessionTracker.kt`.
+  - Populated `startingBattery` in the stats construction block: set to `startBattery` when ACTIVE, `0` when IDLE.
+- **Acceptance**:
+  - `SessionStats` exposes `startingBattery` with default `0`.
+  - When session is ACTIVE, value equals the battery level at session start.
+  - When IDLE, value is `0`.
+  - `./gradlew assembleDebug` passes.
+
 ### 2026-03-25 — Complete T-043 ProgramRepository with Default Preset Seeding (Switch/Worker)
 
 - **Origin**: Merge from `claude/T-043-program-repository` to `dev`


### PR DESCRIPTION
## Summary

- Adds `startingBattery: Int = 0` field to the `SessionStats` data class in `SessionTracker.kt`
- Populates `startingBattery` in the stats construction block: equals `startBattery` when session is ACTIVE, `0` when IDLE
- Exposes the already-tracked private `startBattery` field so the active-session UI (T-068) can display it

## Test plan

- [ ] Verify `SessionStats.startingBattery` is `0` when state is IDLE
- [ ] Verify `SessionStats.startingBattery` equals the battery level at session start when state is ACTIVE
- [ ] Confirm private `startBattery` field is still used for `batteryDrain` and `drainRatePctPerMin` calculations (unchanged)
- [ ] `./gradlew assembleDebug` passes with no errors

https://claude.ai/code/session_016powBhUqRGZRRMqukyCGBx