### PR TITLE
T-049 — SessionsTabFragment: Sessions List Sub-Page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@
   - `AppDatabase.version` is `4` with `SessionProgram::class` in entity list
   - `SessionProgramDao` provided via `AppModule`
 
+### 2026-03-25 14:30 — T-049: Extract SessionsTabFragment from HistoryFragment (Apoc/Worker)
+
+- **Origin**: Branch `claude/T-049-sessions-tab-fragment` → PR to `dev`
+- **Task**: T-049 (`ready` → `done`)
+- **Changes**:
+  - Created `app/src/main/java/com/sbtracker/ui/SessionsTabFragment.kt`: new fragment inflating `fragment_sessions_tab.xml`, containing RecyclerView + SessionHistoryAdapter, sort bar, device filter chips, clear all dialog, and export button. Uses `activityViewModels()` for `bleVm` and `historyVm`.
+  - Created `app/src/main/res/layout/fragment_sessions_tab.xml`: ScrollView > LinearLayout wrapping session count TextView, device filter HorizontalScrollView, sort bar HorizontalScrollView, RecyclerView, clear button, and export ImageButton.
+  - Updated `app/src/main/java/com/sbtracker/ui/HistoryFragment.kt`: removed session list, sort bar, device filter chip, clear, and export code blocks. Analytics, health, and charts sections remain.
+
 ### 2026-03-25 12:00 — T-067: Add startingBattery to SessionStats (Apoc/Worker)
 
 - **Origin**: Branch `claude/T-067-session-stats-starting-battery` → PR to `dev`

--- a/app/src/main/java/com/sbtracker/ui/HistoryFragment.kt
+++ b/app/src/main/java/com/sbtracker/ui/HistoryFragment.kt
@@ -6,13 +6,10 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
-import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
-import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
 import com.sbtracker.*
 import com.sbtracker.data.SessionSummary
 import com.sbtracker.util.formatDurationShort
@@ -74,16 +71,6 @@ class HistoryFragment : Fragment() {
         val tvTotalDaysActive   = view.findViewById<TextView>(R.id.tv_total_days_active)
         val tvAvgHeatUp         = view.findViewById<TextView>(R.id.tv_avg_heat_up)
 
-        // ── Session list + controls ───────────────────────────────────────────
-        val rv           = view.findViewById<RecyclerView>(R.id.rv_history)
-        val tvCount      = view.findViewById<TextView>(R.id.tv_history_count)
-        val llDeviceFilter = view.findViewById<android.widget.LinearLayout>(R.id.ll_device_filter)
-        val tvSortDate     = view.findViewById<TextView>(R.id.tv_sort_date)
-        val tvSortHits     = view.findViewById<TextView>(R.id.tv_sort_hits)
-        val tvSortDuration = view.findViewById<TextView>(R.id.tv_sort_duration)
-        val tvSortDrain    = view.findViewById<TextView>(R.id.tv_sort_drain)
-        val tvSortTemp     = view.findViewById<TextView>(R.id.tv_sort_temp)
-
         // ── Health & Intake card ──────────────────────────────────────────────
         val tvIntakeTotalAll = view.findViewById<TextView>(R.id.tvIntakeTotalAll)
         val tvIntakeWeek     = view.findViewById<TextView>(R.id.tvIntakeWeek)
@@ -113,41 +100,6 @@ class HistoryFragment : Fragment() {
         headerAverages.setOnClickListener { toggleSection(contentAverages, tvExpandAverages) }
         headerInsights.setOnClickListener { toggleSection(contentInsights, tvExpandInsights) }
 
-        // ── RecyclerView setup ────────────────────────────────────────────────
-
-        val adapter = SessionHistoryAdapter(
-            onSessionClick = { openSessionReport(it) },
-            onDeleteClick = { activity.confirmDelete(it) }
-        )
-        rv.layoutManager = LinearLayoutManager(context)
-        rv.adapter = adapter
-
-        // ── Sort bar ──────────────────────────────────────────────────────────
-
-        tvSortDate.setOnClickListener     { historyVm.setSessionSort(HistoryViewModel.SessionSort.DATE) }
-        tvSortHits.setOnClickListener     { historyVm.setSessionSort(HistoryViewModel.SessionSort.HITS) }
-        tvSortDuration.setOnClickListener { historyVm.setSessionSort(HistoryViewModel.SessionSort.DURATION) }
-        tvSortDrain.setOnClickListener    { historyVm.setSessionSort(HistoryViewModel.SessionSort.DRAIN) }
-        tvSortTemp.setOnClickListener     { historyVm.setSessionSort(HistoryViewModel.SessionSort.TEMP) }
-
-        viewLifecycleOwner.lifecycleScope.launch {
-            historyVm.sessionSort.collect { sort ->
-                val sortViews = listOf(
-                    tvSortDate     to HistoryViewModel.SessionSort.DATE,
-                    tvSortHits     to HistoryViewModel.SessionSort.HITS,
-                    tvSortDuration to HistoryViewModel.SessionSort.DURATION,
-                    tvSortDrain    to HistoryViewModel.SessionSort.DRAIN,
-                    tvSortTemp     to HistoryViewModel.SessionSort.TEMP
-                )
-                sortViews.forEach { (tv, s) ->
-                    val active = s == sort
-                    tv.setTextColor(ContextCompat.getColor(requireContext(), if (active) R.color.color_blue else R.color.color_gray_mid))
-                    tv.setTypeface(null, if (active) android.graphics.Typeface.BOLD else android.graphics.Typeface.NORMAL)
-                    tv.setBackgroundResource(if (active) R.drawable.bg_badge_blue else 0)
-                }
-            }
-        }
-
         // ── Period toggle ─────────────────────────────────────────────────────
 
         tvPeriodDay.setOnClickListener  { historyVm.setGraphPeriod(HistoryViewModel.GraphPeriod.DAY) }
@@ -162,16 +114,6 @@ class HistoryFragment : Fragment() {
                 tvPeriodWeek.setTextColor(ContextCompat.getColor(requireContext(), if (!dayActive) R.color.color_blue else R.color.color_gray_mid))
                 tvPeriodWeek.setTypeface(null, if (!dayActive) android.graphics.Typeface.BOLD else android.graphics.Typeface.NORMAL)
                 tvPeriodWeek.setBackgroundResource(if (!dayActive) R.drawable.bg_badge_blue else 0)
-            }
-        }
-
-        // ── Device filter chips ───────────────────────────────────────────────
-
-        viewLifecycleOwner.lifecycleScope.launch {
-            combine(bleVm.knownDevices, historyVm.sessionFilter) { devices, filter ->
-                devices to filter
-            }.collect { (devices, filter) ->
-                buildDeviceFilterChips(devices, filter, llDeviceFilter)
             }
         }
 
@@ -292,95 +234,6 @@ class HistoryFragment : Fragment() {
             }
         }
 
-        // ── Session History List ──────────────────────────────────────────────
-        viewLifecycleOwner.lifecycleScope.launch {
-            combine(historyVm.sessionHistory, historyVm.sessionFilter, bleVm.activeDevice) { items, filter, device ->
-                Triple(items, filter, device)
-            }.collect { (items, filter, device) ->
-                adapter.submitList(items)
-                val sessions = items.count { it is HistoryItem.SessionItem }
-                val charges  = items.count { it is HistoryItem.ChargeItem }
-                val countText = when {
-                    sessions > 0 && charges > 0 -> "$sessions sessions · $charges charges"
-                    sessions > 0 -> "$sessions sessions"
-                    charges  > 0 -> "$charges charges"
-                    else -> "No history"
-                }
-                // Show scope indicator when viewing all devices
-                val scopeText = if (filter == "all" && device != null) {
-                    val label = device.deviceType.ifEmpty { device.serialNumber.takeLast(6) }
-                    "$countText  ·  Stats for $label"
-                } else countText
-                tvCount.text = scopeText
-            }
-        }
-
-        // ── Clear All (with confirmation) ─────────────────────────────────────
-        view.findViewById<TextView>(R.id.tv_history_clear).setOnClickListener {
-            AlertDialog.Builder(requireContext(), android.R.style.Theme_DeviceDefault_Dialog)
-                .setTitle("Clear All History")
-                .setMessage("This will permanently delete all sessions, hits, charge cycles, and device status logs for the current device.\n\nThis cannot be undone.")
-                .setPositiveButton("Delete Everything") { _, _ ->
-                    val device = bleVm.activeDevice.value ?: return@setPositiveButton
-                    historyVm.clearSessionHistory(device)
-                }
-                .setNegativeButton("Cancel", null)
-                .show()
-        }
-
-        // ── Export ────────────────────────────────────────────────────────────
-        view.findViewById<View>(R.id.btn_export_history).setOnClickListener {
-            historyVm.exportHistoryCsv()
-        }
-    }
-
-    private fun buildDeviceFilterChips(
-        devices: List<BleViewModel.SavedDevice>,
-        activeFilter: String?,
-        container: android.widget.LinearLayout
-    ) {
-        container.removeAllViews()
-        val activeSerial = bleVm.activeDevice.value?.serialNumber
-
-        val mineLabel = bleVm.activeDevice.value?.deviceType?.ifEmpty { "Device" } ?: "Mine"
-        container.addView(makeChip(mineLabel, activeFilter == null) {
-            historyVm.setSessionFilter(null)
-        })
-
-        if (devices.size > 1) {
-            container.addView(makeChip("All", activeFilter == "all") {
-                historyVm.setSessionFilter("all")
-            })
-        }
-
-        devices.filter { it.serialNumber != activeSerial }.forEach { device ->
-            val label = device.deviceType.ifEmpty { device.serialNumber.takeLast(6) }
-            val active = activeFilter == device.serialNumber || activeFilter == device.deviceAddress
-            container.addView(makeChip(label, active, {
-                historyVm.setSessionFilter(device.serialNumber)
-            }).also { chip ->
-                chip.setOnLongClickListener {
-                    android.widget.Toast.makeText(requireContext(), device.serialNumber, android.widget.Toast.LENGTH_SHORT).show()
-                    true
-                }
-            })
-        }
-    }
-
-    private fun makeChip(label: String, selected: Boolean, onClick: (() -> Unit)? = null): TextView {
-        return TextView(requireContext()).apply {
-            text = label
-            textSize = 12f
-            setTextColor(ContextCompat.getColor(requireContext(), if (selected) R.color.color_blue else R.color.color_gray_mid))
-            setTypeface(null, if (selected) android.graphics.Typeface.BOLD else android.graphics.Typeface.NORMAL)
-            setPadding(24, 10, 24, 10)
-            if (selected) setBackgroundResource(R.drawable.bg_badge_blue)
-            onClick?.let { setOnClickListener { it() } }
-            layoutParams = android.widget.LinearLayout.LayoutParams(
-                android.widget.LinearLayout.LayoutParams.WRAP_CONTENT,
-                android.widget.LinearLayout.LayoutParams.WRAP_CONTENT
-            ).also { it.marginEnd = 8 }
-        }
     }
 
     private fun openSessionReport(s: SessionSummary) {

--- a/app/src/main/java/com/sbtracker/ui/SessionsTabFragment.kt
+++ b/app/src/main/java/com/sbtracker/ui/SessionsTabFragment.kt
@@ -1,0 +1,184 @@
+package com.sbtracker.ui
+
+import android.content.Intent
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.appcompat.app.AlertDialog
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.sbtracker.*
+import com.sbtracker.data.SessionSummary
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.launch
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class SessionsTabFragment : Fragment() {
+    private val bleVm: BleViewModel by activityViewModels()
+    private val historyVm: HistoryViewModel by activityViewModels()
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
+        inflater.inflate(R.layout.fragment_sessions_tab, container, false)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        val activity = requireActivity() as MainActivity
+
+        val rv             = view.findViewById<RecyclerView>(R.id.rv_history)
+        val tvCount        = view.findViewById<TextView>(R.id.tv_history_count)
+        val llDeviceFilter = view.findViewById<android.widget.LinearLayout>(R.id.ll_device_filter)
+        val tvSortDate     = view.findViewById<TextView>(R.id.tv_sort_date)
+        val tvSortHits     = view.findViewById<TextView>(R.id.tv_sort_hits)
+        val tvSortDuration = view.findViewById<TextView>(R.id.tv_sort_duration)
+        val tvSortDrain    = view.findViewById<TextView>(R.id.tv_sort_drain)
+        val tvSortTemp     = view.findViewById<TextView>(R.id.tv_sort_temp)
+
+        // ── RecyclerView setup ────────────────────────────────────────────────
+
+        val adapter = SessionHistoryAdapter(
+            onSessionClick = { openSessionReport(it) },
+            onDeleteClick = { activity.confirmDelete(it) }
+        )
+        rv.layoutManager = LinearLayoutManager(context)
+        rv.adapter = adapter
+
+        // ── Sort bar ──────────────────────────────────────────────────────────
+
+        tvSortDate.setOnClickListener     { historyVm.setSessionSort(HistoryViewModel.SessionSort.DATE) }
+        tvSortHits.setOnClickListener     { historyVm.setSessionSort(HistoryViewModel.SessionSort.HITS) }
+        tvSortDuration.setOnClickListener { historyVm.setSessionSort(HistoryViewModel.SessionSort.DURATION) }
+        tvSortDrain.setOnClickListener    { historyVm.setSessionSort(HistoryViewModel.SessionSort.DRAIN) }
+        tvSortTemp.setOnClickListener     { historyVm.setSessionSort(HistoryViewModel.SessionSort.TEMP) }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            historyVm.sessionSort.collect { sort ->
+                val sortViews = listOf(
+                    tvSortDate     to HistoryViewModel.SessionSort.DATE,
+                    tvSortHits     to HistoryViewModel.SessionSort.HITS,
+                    tvSortDuration to HistoryViewModel.SessionSort.DURATION,
+                    tvSortDrain    to HistoryViewModel.SessionSort.DRAIN,
+                    tvSortTemp     to HistoryViewModel.SessionSort.TEMP
+                )
+                sortViews.forEach { (tv, s) ->
+                    val active = s == sort
+                    tv.setTextColor(ContextCompat.getColor(requireContext(), if (active) R.color.color_blue else R.color.color_gray_mid))
+                    tv.setTypeface(null, if (active) android.graphics.Typeface.BOLD else android.graphics.Typeface.NORMAL)
+                    tv.setBackgroundResource(if (active) R.drawable.bg_badge_blue else 0)
+                }
+            }
+        }
+
+        // ── Device filter chips ───────────────────────────────────────────────
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            combine(bleVm.knownDevices, historyVm.sessionFilter) { devices, filter ->
+                devices to filter
+            }.collect { (devices, filter) ->
+                buildDeviceFilterChips(devices, filter, llDeviceFilter)
+            }
+        }
+
+        // ── Session History List ──────────────────────────────────────────────
+        viewLifecycleOwner.lifecycleScope.launch {
+            combine(historyVm.sessionHistory, historyVm.sessionFilter, bleVm.activeDevice) { items, filter, device ->
+                Triple(items, filter, device)
+            }.collect { (items, filter, device) ->
+                adapter.submitList(items)
+                val sessions = items.count { it is HistoryItem.SessionItem }
+                val charges  = items.count { it is HistoryItem.ChargeItem }
+                val countText = when {
+                    sessions > 0 && charges > 0 -> "$sessions sessions · $charges charges"
+                    sessions > 0 -> "$sessions sessions"
+                    charges  > 0 -> "$charges charges"
+                    else -> "No history"
+                }
+                // Show scope indicator when viewing all devices
+                val scopeText = if (filter == "all" && device != null) {
+                    val label = device.deviceType.ifEmpty { device.serialNumber.takeLast(6) }
+                    "$countText  ·  Stats for $label"
+                } else countText
+                tvCount.text = scopeText
+            }
+        }
+
+        // ── Clear All (with confirmation) ─────────────────────────────────────
+        view.findViewById<TextView>(R.id.tv_history_clear).setOnClickListener {
+            AlertDialog.Builder(requireContext(), android.R.style.Theme_DeviceDefault_Dialog)
+                .setTitle("Clear All History")
+                .setMessage("This will permanently delete all sessions, hits, charge cycles, and device status logs for the current device.\n\nThis cannot be undone.")
+                .setPositiveButton("Delete Everything") { _, _ ->
+                    val device = bleVm.activeDevice.value ?: return@setPositiveButton
+                    historyVm.clearSessionHistory(device)
+                }
+                .setNegativeButton("Cancel", null)
+                .show()
+        }
+
+        // ── Export ────────────────────────────────────────────────────────────
+        view.findViewById<View>(R.id.btn_export_history).setOnClickListener {
+            historyVm.exportHistoryCsv()
+        }
+    }
+
+    private fun buildDeviceFilterChips(
+        devices: List<BleViewModel.SavedDevice>,
+        activeFilter: String?,
+        container: android.widget.LinearLayout
+    ) {
+        container.removeAllViews()
+        val activeSerial = bleVm.activeDevice.value?.serialNumber
+
+        val mineLabel = bleVm.activeDevice.value?.deviceType?.ifEmpty { "Device" } ?: "Mine"
+        container.addView(makeChip(mineLabel, activeFilter == null) {
+            historyVm.setSessionFilter(null)
+        })
+
+        if (devices.size > 1) {
+            container.addView(makeChip("All", activeFilter == "all") {
+                historyVm.setSessionFilter("all")
+            })
+        }
+
+        devices.filter { it.serialNumber != activeSerial }.forEach { device ->
+            val label = device.deviceType.ifEmpty { device.serialNumber.takeLast(6) }
+            val active = activeFilter == device.serialNumber || activeFilter == device.deviceAddress
+            container.addView(makeChip(label, active, {
+                historyVm.setSessionFilter(device.serialNumber)
+            }).also { chip ->
+                chip.setOnLongClickListener {
+                    android.widget.Toast.makeText(requireContext(), device.serialNumber, android.widget.Toast.LENGTH_SHORT).show()
+                    true
+                }
+            })
+        }
+    }
+
+    private fun makeChip(label: String, selected: Boolean, onClick: (() -> Unit)? = null): TextView {
+        return TextView(requireContext()).apply {
+            text = label
+            textSize = 12f
+            setTextColor(ContextCompat.getColor(requireContext(), if (selected) R.color.color_blue else R.color.color_gray_mid))
+            setTypeface(null, if (selected) android.graphics.Typeface.BOLD else android.graphics.Typeface.NORMAL)
+            setPadding(24, 10, 24, 10)
+            if (selected) setBackgroundResource(R.drawable.bg_badge_blue)
+            onClick?.let { setOnClickListener { it() } }
+            layoutParams = android.widget.LinearLayout.LayoutParams(
+                android.widget.LinearLayout.LayoutParams.WRAP_CONTENT,
+                android.widget.LinearLayout.LayoutParams.WRAP_CONTENT
+            ).also { it.marginEnd = 8 }
+        }
+    }
+
+    private fun openSessionReport(s: SessionSummary) {
+        val intent = Intent(requireContext(), SessionReportActivity::class.java).apply {
+            putExtra("session_id", s.id)
+        }
+        startActivity(intent)
+    }
+}

--- a/app/src/main/res/layout/fragment_sessions_tab.xml
+++ b/app/src/main/res/layout/fragment_sessions_tab.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="#000000"
+    android:fillViewport="true">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingBottom="80dp">
+
+        <!-- Count subtitle -->
+        <TextView
+            android:id="@+id/tv_history_count"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="24dp"
+            android:layout_marginTop="16dp"
+            android:text="0 Sessions"
+            android:textColor="#80A88F"
+            android:textSize="14sp" />
+
+        <!-- Device Filter Chips -->
+        <HorizontalScrollView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:paddingHorizontal="24dp"
+            android:scrollbars="none">
+            <LinearLayout
+                android:id="@+id/ll_device_filter"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal" />
+        </HorizontalScrollView>
+
+        <!-- Sort Bar -->
+        <HorizontalScrollView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:paddingHorizontal="16dp"
+            android:scrollbars="none">
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <TextView android:id="@+id/tv_sort_date" android:layout_width="wrap_content" android:layout_height="wrap_content" android:paddingHorizontal="14dp" android:paddingVertical="6dp" android:text="Date" android:textColor="#00FF41" android:textSize="13sp" android:textStyle="bold" android:background="@drawable/bg_badge_blue" />
+                <TextView android:id="@+id/tv_sort_hits" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginStart="8dp" android:paddingHorizontal="14dp" android:paddingVertical="6dp" android:text="Hits" android:textColor="#636366" android:textSize="13sp" />
+                <TextView android:id="@+id/tv_sort_duration" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginStart="8dp" android:paddingHorizontal="14dp" android:paddingVertical="6dp" android:text="Duration" android:textColor="#636366" android:textSize="13sp" />
+                <TextView android:id="@+id/tv_sort_drain" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginStart="8dp" android:paddingHorizontal="14dp" android:paddingVertical="6dp" android:text="Drain" android:textColor="#636366" android:textSize="13sp" />
+                <TextView android:id="@+id/tv_sort_temp" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginStart="8dp" android:paddingHorizontal="14dp" android:paddingVertical="6dp" android:text="Temp" android:textColor="#636366" android:textSize="13sp" />
+            </LinearLayout>
+        </HorizontalScrollView>
+
+        <!-- Session List -->
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rv_history"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:clipToPadding="false"
+            android:nestedScrollingEnabled="false"
+            android:paddingHorizontal="16dp"
+            tools:listitem="@layout/item_session" />
+
+        <!-- Clear All (bottom, safe) -->
+        <TextView
+            android:id="@+id/tv_history_clear"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginTop="24dp"
+            android:paddingHorizontal="24dp"
+            android:paddingVertical="12dp"
+            android:text="Clear All History"
+            android:textColor="#FF453A"
+            android:textSize="14sp" />
+
+        <!-- Export button -->
+        <ImageButton
+            android:id="@+id/btn_export_history"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginTop="8dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:src="@android:drawable/ic_menu_save"
+            app:tint="#00FF41"
+            xmlns:app="http://schemas.android.com/apk/res-auto" />
+
+    </LinearLayout>
+</ScrollView>


### PR DESCRIPTION
## Summary

- Created `SessionsTabFragment` inflating new `fragment_sessions_tab.xml` with session list, sort bar, device filter chips, clear all dialog, and export button
- New layout wraps all session controls in a `ScrollView > LinearLayout` root
- Removed extracted code blocks from `HistoryFragment` — analytics, charts, health sections remain intact
- Both fragments share `bleVm` and `historyVm` via `activityViewModels()` (no ViewModel duplication)

## Test plan

- [ ] `SessionsTabFragment` inflates without crash
- [ ] Session list displays sessions and charges with correct count text
- [ ] Sort bar (Date/Hits/Duration/Drain/Temp) updates active highlight via `historyVm.sessionSort`
- [ ] Device filter chips build correctly from `bleVm.knownDevices`
- [ ] Clear All button shows confirmation dialog and deletes on confirm
- [ ] Export button triggers `historyVm.exportHistoryCsv()`
- [ ] `HistoryFragment` still shows analytics/charts/health with no missing reference errors
- [ ] `./gradlew assembleDebug` passes

https://claude.ai/code/session_016powBhUqRGZRRMqukyCGBx