### PR TITLE
revert: T-076 — Remove premature hit classification model

### DIFF
--- a/app/src/main/java/com/sbtracker/BleConstants.kt
+++ b/app/src/main/java/com/sbtracker/BleConstants.kt
@@ -82,6 +82,4 @@ object BleConstants {
     /** Temperature dip (°C) that triggers hit detection. Single source of truth. */
     const val TEMP_DIP_THRESHOLD_C = 2
 
-    /** Minimum hit duration (ms) to classify a hit as a large hit / rip. Tune after real-device validation. */
-    const val LARGE_HIT_DURATION_MS = 3000L
 }

--- a/app/src/main/java/com/sbtracker/analytics/AnalyticsModels.kt
+++ b/app/src/main/java/com/sbtracker/analytics/AnalyticsModels.kt
@@ -161,24 +161,3 @@ data class IntakeStats(
     val gramsPerDay30d: Float = 0f
 )
 
-/**
- * Per-session hit classification counts derived from the hits table.
- * Used to power the hit-achievement display on the Analytics tab.
- *
- * Classification is time-based: a hit is "large" if its durationMs
- * exceeds [BleConstants.LARGE_HIT_DURATION_MS].
- *
- * This is a framework skeleton — add achievement fields here as needed.
- */
-data class HitAnalysisSummary(
-    /** Total hits classified across all sessions in scope. */
-    val totalHits: Int = 0,
-    /** Hits whose duration exceeded LARGE_HIT_DURATION_MS. */
-    val largeHitCount: Int = 0,
-    /** Hits whose duration was below LARGE_HIT_DURATION_MS. */
-    val sipCount: Int = 0,
-    /** Highest large-hit count recorded in a single session. */
-    val mostLargeHitsInSession: Int = 0,
-    /** Highest sip count recorded in a single session. */
-    val mostSipsInSession: Int = 0
-)


### PR DESCRIPTION
## Why

`HitAnalysisSummary` and `LARGE_HIT_DURATION_MS = 3000L` were added as a "framework skeleton" before any real design existed for hit quality analytics. The threshold is arbitrary, there is no live display during a hit, no session-report logging, no achievement tracking, and no timeline. Shipping undefined scaffolding into the data model creates false confidence and wrong contracts downstream.

## What this removes
- `BleConstants.LARGE_HIT_DURATION_MS` constant
- `HitAnalysisSummary` data class from `AnalyticsModels.kt`

## What comes next
Oracle consultation on F-052 will produce a full spec before any model is re-introduced.

https://claude.ai/code/session_016powBhUqRGZRRMqukyCGBx