### PR TITLE
F-027: PR #66 cleanup — bug fixes, task docs, aspirational scope captured

### DIFF
--- a/.agents/TASKS.md
+++ b/.agents/TASKS.md
@@ -96,11 +96,14 @@ main  ← stable, merges only from dev
 |---|---|---|---|---|
 | T-042 | `done` | SessionProgram Entity + DAO + Migration 3→4 (incl. appliedProgramId on session_metadata) | [T-042](tasks/T-042-session-program-entity.md) | — |
 | T-043 | `done` | ProgramRepository: CRUD + Default Preset Seeding | [T-043](tasks/T-043-program-repository.md) | T-042 |
-| T-044 | `ready` | Programs List UI in SettingsFragment | [T-044](tasks/T-044-programs-list-ui.md) | T-043 |
-| T-045 | `blocked` | Create/Edit Program Dialog | [T-045](tasks/T-045-create-edit-program-dialog.md) | T-044 |
-| T-046 | `blocked` | Apply Program on Heater Start (setBoost, cancellable Job) | [T-046](tasks/T-046-apply-program-on-start.md) | T-045 |
+| T-044 | `done` | Program Grid + Editor UI in SessionFragment (2×3 grid, table step editor) | [T-044](tasks/T-044-programs-list-ui.md) | T-043 |
+| T-045 | `done` | Create/Edit Program Dialog (table UI: Step# / Temp / Time rows) | [T-045](tasks/T-045-create-edit-program-dialog.md) | T-044 |
+| T-046 | `ready` | Apply Program on Heater Start (chip row, startSessionWithProgram, setBoost job) | [T-046](tasks/T-046-apply-program-on-start.md) | T-045 |
 | T-056 | `blocked` | Record Program Attribution to session_metadata on Session Complete | [T-056](tasks/T-056-record-program-attribution.md) | T-046 |
 | T-057 | `blocked` | Display Program Name in Session History + Session Report | [T-057](tasks/T-057-display-program-in-history.md) | T-056 |
+| T-083 | `ready` | DB Migration v4→5: stayOnAtEnd field on SessionProgram | [T-083](tasks/T-083-session-program-stay-on-migration.md) | — |
+| T-084 | `ready` | Program Drain Estimation: AnalyticsRepository + HistoryViewModel + SessionViewModel helpers | [T-084](tasks/T-084-program-drain-estimation.md) | T-043 |
+| T-085 | `blocked` | SessionFragment: Program Hero Window + Drain Estimate Preview | [T-085](tasks/T-085-program-hero-window-and-drain-preview.md) | T-046, T-084 |
 
 ## Phase 3 — F-055 Homepage Redesign
 

--- a/.agents/tasks/T-083-session-program-stay-on-migration.md
+++ b/.agents/tasks/T-083-session-program-stay-on-migration.md
@@ -1,0 +1,72 @@
+# T-083 — DB Migration v4→5: stayOnAtEnd field on SessionProgram
+
+**Phase**: Phase 3 — F-027 Session Programs/Presets
+**Blocked by**: —
+**Estimated diff**: ~25 lines across 3 files
+
+## Goal
+Add `stayOnAtEnd: Boolean` to the `SessionProgram` entity and ship the corresponding
+Room migration so the device keeps heating after all boost steps complete when this flag
+is set. The execution logic that *reads* the flag belongs to T-046.
+
+## Read these files first
+- `app/src/main/java/com/sbtracker/data/SessionProgram.kt` — entity to modify
+- `app/src/main/java/com/sbtracker/data/AppDatabase.kt` — bump version 4 → 5
+- `app/src/main/java/com/sbtracker/di/AppModule.kt` — add MIGRATION_4_5 following the
+  exact same pattern used for MIGRATION_3_4
+
+## Change only these files
+- `app/src/main/java/com/sbtracker/data/SessionProgram.kt`
+- `app/src/main/java/com/sbtracker/data/AppDatabase.kt`
+- `app/src/main/java/com/sbtracker/di/AppModule.kt`
+
+## Steps
+
+### 1. `SessionProgram.kt` — add field
+
+```kotlin
+data class SessionProgram(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val name:           String,
+    val targetTempC:    Int,
+    val boostStepsJson: String = "[]",
+    val isDefault:      Boolean = false,
+    val stayOnAtEnd:    Boolean = false   // ← new; keep heater on after boost steps complete
+)
+```
+
+### 2. `AppDatabase.kt` — bump version
+
+```kotlin
+version = 5,   // was 4
+```
+
+### 3. `AppModule.kt` — add MIGRATION_4_5
+
+Inside `provideDatabase()`, after the MIGRATION_3_4 block:
+
+```kotlin
+val MIGRATION_4_5 = object : Migration(4, 5) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            "ALTER TABLE `session_programs` ADD COLUMN `stayOnAtEnd` INTEGER NOT NULL DEFAULT 0"
+        )
+    }
+}
+```
+
+Then add `MIGRATION_4_5` to the `.addMigrations(...)` call.
+
+### 4. Run `./gradlew assembleDebug` and confirm it passes.
+
+## Acceptance criteria
+- [ ] `SessionProgram.stayOnAtEnd` field exists with default `false`
+- [ ] `AppDatabase.version` is 5
+- [ ] `MIGRATION_4_5` is defined and wired into `.addMigrations()`
+- [ ] `./gradlew assembleDebug` passes
+
+## Do NOT
+- Implement any execution logic reading `stayOnAtEnd` — that is part of T-046
+- Add a UI toggle for `stayOnAtEnd` — that is a future editor enhancement
+- Skip straight from 4 to 5 without an explicit Migration object
+- Modify `ProgramRepository`, `SessionFragment`, or any ViewModel

--- a/.agents/tasks/T-084-program-drain-estimation.md
+++ b/.agents/tasks/T-084-program-drain-estimation.md
@@ -1,0 +1,99 @@
+# T-084 — Program Drain Estimation: AnalyticsRepository + HistoryViewModel + SessionViewModel
+
+**Phase**: Phase 3 — F-027 Session Programs/Presets
+**Blocked by**: T-043 (done)
+**Estimated diff**: ~50 lines across 3 files
+
+## Goal
+Compute an average battery drain rate (% per minute) from session history and expose it
+so that `SessionFragment` can show an estimated battery cost when a program is selected.
+The UI that displays this estimate is wired in T-085.
+
+## Read these files first
+- `app/src/main/java/com/sbtracker/analytics/AnalyticsRepository.kt` — add `computeAvgDrainPerMinute()`
+- `app/src/main/java/com/sbtracker/HistoryViewModel.kt` — expose `avgDrainPerMinute` StateFlow
+- `app/src/main/java/com/sbtracker/SessionViewModel.kt` — add estimation helpers
+
+## Change only these files
+- `app/src/main/java/com/sbtracker/analytics/AnalyticsRepository.kt`
+- `app/src/main/java/com/sbtracker/HistoryViewModel.kt`
+- `app/src/main/java/com/sbtracker/SessionViewModel.kt`
+
+## Steps
+
+### 1. `AnalyticsRepository.kt` — add `computeAvgDrainPerMinute()`
+
+Add alongside the other pure `compute*` functions (they all take `List<SessionSummary>`):
+
+```kotlin
+/**
+ * Returns the average battery drain rate in % per minute, computed from
+ * sessions that have both a positive battery drain and a non-zero duration.
+ * Returns 0.0 when there is no qualifying history.
+ */
+fun computeAvgDrainPerMinute(summaries: List<SessionSummary>): Double {
+    val qualifying = summaries.filter { it.batteryConsumed > 0 && it.durationMs > 0 }
+    if (qualifying.isEmpty()) return 0.0
+    return qualifying.sumOf { it.batteryConsumed.toDouble() / (it.durationMs / 60_000.0) } /
+            qualifying.size
+}
+```
+
+This is a pure function — no DB access, no suspend. Consistent with all other `compute*`
+methods in this class.
+
+### 2. `HistoryViewModel.kt` — expose `avgDrainPerMinute`
+
+Find where `HistoryViewModel` derives stats from `sessionSummaries`. Add:
+
+```kotlin
+val avgDrainPerMinute: StateFlow<Double> = sessionSummaries
+    .map { analyticsRepo.computeAvgDrainPerMinute(it) }
+    .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 0.0)
+```
+
+`analyticsRepo` is already injected into `HistoryViewModel`. No new dependency needed.
+
+### 3. `SessionViewModel.kt` — add estimation helpers
+
+These helpers let `SessionFragment` show an estimate without touching `HistoryViewModel`
+directly (ViewModels should not reference each other):
+
+```kotlin
+/**
+ * Estimates total program duration in minutes by summing step durations from
+ * boostStepsJson. The last step's duration is assumed to be 60 seconds.
+ * Returns 0.0 if the JSON is malformed or the program has no steps.
+ */
+fun estimateProgramDurationMinutes(program: SessionProgram): Double {
+    return try {
+        val arr = org.json.JSONArray(program.boostStepsJson)
+        if (arr.length() == 0) return 0.0
+        val lastOffset = arr.getJSONObject(arr.length() - 1).getInt("offsetSec")
+        (lastOffset + 60) / 60.0   // last step assumed 60s duration
+    } catch (e: Exception) { 0.0 }
+}
+
+/**
+ * Estimates battery drain for a program given the current avg drain rate.
+ * Returns 0 when rate or duration is unknown.
+ */
+fun estimateProgramDrain(program: SessionProgram, avgDrainPerMinute: Double): Int {
+    if (avgDrainPerMinute <= 0.0) return 0
+    return (estimateProgramDurationMinutes(program) * avgDrainPerMinute).toInt()
+}
+```
+
+### 4. Run `./gradlew assembleDebug` and confirm it passes.
+
+## Acceptance criteria
+- [ ] `AnalyticsRepository.computeAvgDrainPerMinute(summaries)` exists and returns 0.0 for empty input
+- [ ] `HistoryViewModel.avgDrainPerMinute: StateFlow<Double>` exists
+- [ ] `SessionViewModel.estimateProgramDurationMinutes(program)` and `estimateProgramDrain(program, rate)` exist
+- [ ] `./gradlew assembleDebug` passes
+
+## Do NOT
+- Access the DB from `computeAvgDrainPerMinute` — it must remain a pure function
+- Inject `HistoryViewModel` into `SessionViewModel` or vice versa
+- Wire any UI in this task — that is T-085
+- Modify `AppDatabase`, migrations, or `SessionProgram` entity

--- a/.agents/tasks/T-085-program-hero-window-and-drain-preview.md
+++ b/.agents/tasks/T-085-program-hero-window-and-drain-preview.md
@@ -1,0 +1,103 @@
+# T-085 — SessionFragment: Program Hero Window + Drain Estimate Preview
+
+**Phase**: Phase 3 — F-027 Session Programs/Presets
+**Blocked by**: T-046, T-084
+**Estimated diff**: ~60 lines in 1 file
+
+## Goal
+When a program is selected from the chip row (T-046) and the device is idle, show:
+1. **Hero window**: the program's estimated total duration in `MM:SS (est.)` format
+   in the session time display (`tvTime`), instead of `00:00`.
+2. **Drain preview**: below the chip row, show estimated battery cost as `−X% (Ym est.)`.
+
+Both displays reset to normal once the session starts.
+
+## Read these files first
+- `app/src/main/java/com/sbtracker/ui/SessionFragment.kt` — understand the flows already
+  collected (`bleVm.sessionStats`, `sessionVm.selectedProgram`), the time TextView
+  (`tvTime`), and where the chip row was added in T-046
+- `app/src/main/java/com/sbtracker/SessionViewModel.kt` — `estimateProgramDurationMinutes()` and `estimateProgramDrain()` added in T-084
+- `app/src/main/java/com/sbtracker/HistoryViewModel.kt` — `avgDrainPerMinute` StateFlow from T-084
+
+## Change only these files
+- `app/src/main/java/com/sbtracker/ui/SessionFragment.kt`
+
+## Steps
+
+### 1. Hero window — estimated time in `tvTime`
+
+In the coroutine that collects `bleVm.sessionStats`, extend the existing time display
+logic. Use `combine` on `bleVm.sessionStats` and `sessionVm.selectedProgram`:
+
+```kotlin
+viewLifecycleOwner.lifecycleScope.launch {
+    combine(bleVm.sessionStats, sessionVm.selectedProgram) { stats, program ->
+        stats to program
+    }.collect { (stats, program) ->
+        val isIdle = stats.state == SessionTracker.State.IDLE   // or heaterMode == 0
+        if (isIdle && program != null) {
+            val totalSec = (sessionVm.estimateProgramDurationMinutes(program) * 60).toLong()
+            tvTime.text = "%02d:%02d (est.)".format(totalSec / 60, totalSec % 60)
+        } else {
+            // Normal elapsed time — already formatted elsewhere; leave existing logic intact
+        }
+    }
+}
+```
+
+> **Important**: only override `tvTime` in the IDLE + program-selected case. Preserve all
+> existing elapsed-time display for active sessions. Do not duplicate the elapsed-time
+> collector — combine into the existing one or add a separate observer that only writes
+> when the condition is met.
+
+### 2. Drain preview — `"−X% (Ym est.)"` label
+
+Add a `TextView` for the drain preview immediately below the chip row added in T-046.
+Create it programmatically alongside the chip row setup:
+
+```kotlin
+val tvDrainPreview = TextView(requireContext()).apply {
+    textSize = 11f
+    setTextColor(ContextCompat.getColor(requireContext(), R.color.color_boost_bar_fill))
+    visibility = View.GONE
+}
+layout.addView(tvDrainPreview)
+```
+
+Then collect the drain estimate reactively:
+
+```kotlin
+viewLifecycleOwner.lifecycleScope.launch {
+    combine(sessionVm.selectedProgram, historyVm.avgDrainPerMinute) { program, rate ->
+        program to rate
+    }.collect { (program, rate) ->
+        if (program != null) {
+            val drain = sessionVm.estimateProgramDrain(program, rate)
+            val mins = sessionVm.estimateProgramDurationMinutes(program).toInt()
+            tvDrainPreview.text = if (drain > 0) "−${drain}% (${mins}m est.)" else "(${mins}m est.)"
+            tvDrainPreview.visibility = View.VISIBLE
+        } else {
+            tvDrainPreview.visibility = View.GONE
+        }
+    }
+}
+```
+
+Also hide `tvDrainPreview` once the session starts (same condition used to hide the chip
+row in T-046).
+
+### 3. Run `./gradlew assembleDebug` and confirm it passes.
+
+## Acceptance criteria
+- [ ] When program is selected and device is idle, `tvTime` shows `"MM:SS (est.)"` using estimated duration
+- [ ] Once session starts, `tvTime` reverts to normal elapsed time
+- [ ] When program is selected, drain preview label is visible below chip row
+- [ ] Drain preview is hidden when no program is selected or during active session
+- [ ] If `avgDrainPerMinute` is 0 (no history), only duration is shown, no crash
+- [ ] `./gradlew assembleDebug` passes
+
+## Do NOT
+- Persist the preview state across Fragment recreation
+- Add any new XML layout files
+- Modify `HistoryViewModel`, `SessionViewModel`, or `AnalyticsRepository` in this task
+- Show drain preview during an active session — hide it with the chip row

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -147,58 +147,32 @@ The codebase is currently in the "Final Hardening" phase. To reach a technical A
 
 ---
 
-### F-027: Session Programs UI — Session Page Integration
+### F-027: Session Programs — Implementation Status & Remaining Work
 
-*Status: **In Development** — Session page UI for program selection and configuration.*
+*Status: **In Development** — Library management done; execution, persistence, and display pipeline in progress.*
 
-**User Story:**
-As a user, I want to see a 2×3 grid of session programs on the Session page where I can:
-- Quickly select and apply pre-configured heating profiles (3 default + 3 custom)
-- View program details including total duration and estimated battery drain
-- Configure custom programs by defining temperature steps and durations
-- Apply a program to immediately start a session with that profile
+#### What's done (in `dev`)
+| Task | What shipped |
+|------|-------------|
+| T-042 | `SessionProgram` entity, `SessionProgramDao`, Migration 3→4 (creates `session_programs` + `appliedProgramId` column on `session_metadata`) |
+| T-043 | `ProgramRepository` CRUD + default preset seeding |
+| T-044/T-045 | `setupProgramsGrid()` 2×3 grid + `showProgramEditor()` table dialog (Step# / Temp / Time) in `SessionFragment` — programs can be created, edited, deleted |
 
-**Technical Architecture:**
-- **Data Model**: `SessionProgram` entity contains `boostStepsJson` (array of `{offsetSec: Int, boostC: Int}`)
-  - Each step represents a boost offset to apply at a given time offset
-  - Example: `[{offsetSec: 0, boostC: 0}, {offsetSec: 60, boostC: 5}]` = normal temp for 60s, then +5° boost
-- **UI Placement**: `SessionFragment` (active session page)
-- **Layout**: Programmatic Views (no new XML layouts — follow existing pattern)
+#### Remaining tasks (in order)
+| Task | What it delivers |
+|------|-----------------|
+| **T-083** `ready` | DB Migration v4→5: `stayOnAtEnd: Boolean` field on `SessionProgram` (infrastructure; no UI yet) |
+| **T-084** `ready` | `AnalyticsRepository.computeAvgDrainPerMinute()` + `HistoryViewModel.avgDrainPerMinute` StateFlow + `SessionViewModel` estimation helpers |
+| **T-046** `ready` | Chip row UI for program selection, `startSessionWithProgram()`, `ActiveProgramHolder` singleton, `setBoost()` coroutine job — **programs execute for the first time** |
+| **T-056** `blocked by T-046` | `MainViewModel` writes `appliedProgramId` to `session_metadata` on session complete via `ActiveProgramHolder.consume()` |
+| **T-057** `blocked by T-056` | `appliedProgramName` in `SessionSummary`, history badge `▶ ProgramName`, `SessionReportActivity` program line |
+| **T-085** `blocked by T-046, T-084` | SessionFragment hero window `MM:SS (est.)` + drain preview `−X% (Ym est.)` when program is selected and idle |
 
-**UI Components:**
-1. **Program Grid** (2×3):
-   - Top 3: Default programs (non-deletable)
-   - Bottom 3: User custom programs (optional delete button)
-   - Each button shows: program name (label), target temp (subtitle)
-   - Visual state: selected/active program highlighted
-
-2. **Program Editor Dialog**:
-   - Opens when clicking a program or "New Program" button
-   - Sections:
-     - Program name (text input)
-     - Base target temperature (temp selector, 40–230°C)
-     - Steps list:
-       - Each step: time offset (minutes) + boost offset (°C) controls
-       - Add/remove buttons for steps
-       - Auto-calculate total duration and estimated battery drain
-     - Preview: "Total: MM:SS | Est. drain: X%"
-     - Save/Cancel buttons
-
-3. **Program Application**:
-   - Clicking a program button applies it and optionally triggers session start
-   - If session is not running: apply program to staging, optionally auto-start with "IGNITE" button
-   - If session is running: queue boost steps for execution (detailed in T-046)
-
-**Design Constraints:**
-- Reuse existing color scheme and typography (Matrix cyber-green theme)
-- Keep program selection intuitive and visually compact
-- Battery drain estimation should use existing `AnalyticsRepository` heuristics
-- Do NOT store user programs in session_metadata on creation — only on session complete (T-056)
-
-**Dependencies:**
-- `SessionViewModel` — extend with program control methods
-- `HistoryViewModel` — reuse battery drain estimation logic
-- `ProgramRepository` — already has CRUD and defaults seeding
+#### Architecture notes
+- `boostStepsJson` format: `[{offsetSec: Int, boostC: Int}, …]` — cumulative offsets from session start; `boostC` is the delta above `targetTempC`
+- Execution uses `setBoost()` (WRITE_BOOST command), never `setTemp(base + boost)` — avoids disrupting hit detection in `SessionTracker`
+- `ActiveProgramHolder` (@Singleton) bridges `SessionViewModel` → `MainViewModel` without a cross-ViewModel dependency
+- `appliedProgramName` is always resolved at query time from `session_programs` — never stored as a string in the DB
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ---
 
+### 2026-03-25 — Fix: Program Editor Save Bug — Eager Text Sync + Temp Validation (Claude)
+
+- **Fixed** `showProgramEditor()` step inputs used `onFocusChangeListener` to sync data to the backing model; if a field still had focus when Save was tapped the last edit was silently dropped. Replaced with `doAfterTextChanged` so `step.temp` / `step.timeSec` stay current on every keystroke.
+- **Fixed** step temperature values were written to JSON without clamping; a user-entered out-of-range temp (e.g. 5°C or 999°C) would propagate to the device. Added `coerceIn(40, 230)` at save time, matching validation already applied to the base temp field.
+- **Fixed** step duration of 0 seconds was accepted; now clamped to a minimum of 1 second via `maxOf(1, …)`.
+
+---
+
 ### 2026-03-25 14:xx — F-027: Program Editor Refinement — Clean Table UI (Claude)
 
 - **Origin**: Branch `claude/session-program-ui-table-refinement` → PR to `dev`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+### 2026-03-25 — F-027: Document Aspirational Scope + Close PR #66 (Claude)
+
+- **Added** task files T-083 (DB migration v4→5 / stayOnAtEnd), T-084 (drain estimation data layer), T-085 (hero window + drain preview UI) to capture the unimplemented bonus features from PR #66
+- **Updated** TASKS.md: T-044/T-045 marked `done` (grid + editor shipped via PRs #64/#65); T-046 unblocked to `ready`; F-027 backlog spec replaced with accurate status table
+- **Closed** PR #66 — its actual 2-file diff was superseded by PR #65 (table UI); the execution/persistence/analytics scope it described is now tracked as T-046, T-056, T-057, T-083–T-085
+
 ### 2026-03-25 — Fix: Program Editor Save Bug — Eager Text Sync + Temp Validation (Claude)
 
 - **Fixed** `showProgramEditor()` step inputs used `onFocusChangeListener` to sync data to the backing model; if a field still had focus when Save was tapped the last edit was silently dropped. Replaced with `doAfterTextChanged` so `step.temp` / `step.timeSec` stay current on every keystroke.

--- a/app/src/main/java/com/sbtracker/ui/SessionFragment.kt
+++ b/app/src/main/java/com/sbtracker/ui/SessionFragment.kt
@@ -13,6 +13,7 @@ import android.widget.EditText
 import android.app.AlertDialog
 import androidx.cardview.widget.CardView
 import androidx.core.content.ContextCompat
+import androidx.core.widget.doAfterTextChanged
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
@@ -441,13 +442,10 @@ class SessionFragment : Fragment() {
 
                 tableContainer.addView(dataRow)
 
-                // Sync inputs to step data
-                tempInput.onFocusChangeListener = android.view.View.OnFocusChangeListener { _, _ ->
-                    step.temp = tempInput.text.toString().toIntOrNull() ?: baseTemp
-                }
-                timeInput.onFocusChangeListener = android.view.View.OnFocusChangeListener { _, _ ->
-                    step.timeSec = timeInput.text.toString().toIntOrNull() ?: 60
-                }
+                // Sync inputs to step data eagerly so Save captures the latest value
+                // even if the field still has focus when the button is tapped.
+                tempInput.doAfterTextChanged { step.temp = it.toString().toIntOrNull() ?: baseTemp }
+                timeInput.doAfterTextChanged { step.timeSec = maxOf(1, it.toString().toIntOrNull() ?: 60) }
             }
 
             // Add Step button
@@ -515,7 +513,8 @@ class SessionFragment : Fragment() {
                     val stepsJson = mutableListOf<String>()
                     var offsetSec = 0
                     steps.forEach { step ->
-                        val boostC = step.temp - newBaseTemp
+                        val clampedTemp = step.temp.coerceIn(40, 230)
+                        val boostC = clampedTemp - newBaseTemp
                         stepsJson.add("{\"offsetSec\":$offsetSec,\"boostC\":$boostC}")
                         offsetSec += step.timeSec
                     }


### PR DESCRIPTION
## Summary

Evaluation and cleanup work following PR #66, which was closed as superseded by #65.

### Bug fixes (`SessionFragment.kt`)

- **Save data loss**: `onFocusChangeListener` only fires on focus change — tapping the AlertDialog Save button while a step field was still focused silently dropped the last edit. Replaced with `doAfterTextChanged` so `step.temp` / `step.timeSec` are always current.
- **Unvalidated step temperatures**: Step temps were written to `boostStepsJson` without range checks; a user could save 5°C or 999°C. Added `coerceIn(40, 230)` at save time, matching the guard already on the base temp field.
- **Zero-duration steps**: `timeSec = 0` was accepted, which would collapse a step. Enforced `maxOf(1, …)`.

### Task registry (`TASKS.md`)

- T-044 / T-045 → `done` (2×3 grid + table editor shipped in `dev` via PRs #64/#65)
- T-046 → `ready` (was blocked on T-045, now unblocked — chip row + execution layer)
- Added **T-083** `ready` — DB migration v4→5: `stayOnAtEnd` field
- Added **T-084** `ready` — drain estimation: `computeAvgDrainPerMinute()`, `avgDrainPerMinute` StateFlow, `estimateProgramDrain/Duration()` helpers
- Added **T-085** `blocked` — hero window `MM:SS (est.)` + drain preview in `SessionFragment` (blocked by T-046 + T-084)

### Documentation (`BACKLOG.md`, `CHANGELOG.md`)

- F-027 draft spec replaced with an accurate done/remaining task table and architecture notes
- CHANGELOG entries for both the bug fix and the documentation pass

## Files changed

| File | Change |
|------|--------|
| `SessionFragment.kt` | 3 bug fixes in `showProgramEditor()` |
| `.agents/TASKS.md` | Status updates + 3 new task rows |
| `.agents/tasks/T-083-session-program-stay-on-migration.md` | New task file |
| `.agents/tasks/T-084-program-drain-estimation.md` | New task file |
| `.agents/tasks/T-085-program-hero-window-and-drain-preview.md` | New task file |
| `BACKLOG.md` | F-027 spec rewritten |
| `CHANGELOG.md` | 2 new entries |

## What's ready to start next

- **T-046** — chip row + `startSessionWithProgram()` + `ActiveProgramHolder` (the main execution task)
- **T-083** — `stayOnAtEnd` migration (small, independent, can run in parallel)
- **T-084** — drain estimation data layer (independent, can run in parallel)

https://claude.ai/code/session_01W1RY64eZhuqWDJhPUVLNcE