### PR TITLE
Refactor feature workflow: move TASKS.md update into PR, remove direct dev push

### DIFF
--- a/.agents/workflows/feature-work.md
+++ b/.agents/workflows/feature-work.md
@@ -48,18 +48,26 @@ dev    ← NEVER push feature code here directly. PRs only.
    git add <changed files>
    git commit -m "T-XXX: description of change"
    ```
-   Do **not** add unrelated files. Do **not** add TASKS.md here — that comes later.
+   Do **not** add unrelated files. Do **not** add TASKS.md here — that comes in the next step.
 
-6. Append one line to `CHANGELOG.md` under `[Unreleased]`, commit it on your branch.
+6. **Mark the task done — commit TASKS.md on your branch:**
+   Edit `.agents/TASKS.md` to change T-XXX status to `done`, then commit it:
+   ```bash
+   git add .agents/TASKS.md
+   git commit -m "meta: T-XXX done"
+   ```
+   This stays on your feature branch and merges with your PR. **Never push directly to `dev`.**
 
-7. **Rebase onto latest `dev` before pushing** to ensure a clean, conflict-free PR:
+7. **Do NOT touch `CHANGELOG.md`.** The Orchestrator writes one consolidated entry after all PRs in the wave merge.
+
+8. **Rebase onto latest `dev` before pushing** to ensure a clean, conflict-free PR:
    ```bash
    git fetch origin dev
    git rebase origin/dev
    ```
    Resolve any conflicts, then `git rebase --continue`.
 
-8. Establish hardline (Push your branch) and upload to the Nebuchadnezzar (open a PR targeting **`dev`**):
+9. Establish hardline (Push your branch) and upload to the Nebuchadnezzar (open a PR targeting **`dev`**):
    ```bash
    git push -u origin claude/T-XXX-description
    ```
@@ -70,21 +78,6 @@ dev    ← NEVER push feature code here directly. PRs only.
    - `body`: summary of changes + `Closes T-XXX`
    - `head`: `claude/T-XXX-description`
    - `base`: `dev`   ← **always dev, never main**
-
-9. **Mark the task done — isolated meta push to `dev`:**
-   Do NOT use `git push origin HEAD:dev` from your feature branch — that pushes feature code too.
-   Instead, make the TASKS.md update from a clean dev base:
-   ```bash   ```
-   git fetch origin dev
-   git checkout -b meta-T-XXX-done origin/dev
-   # Edit .agents/TASKS.md: change status to `done`
-   git add .agents/TASKS.md
-   git commit -m "meta: T-XXX done"
-   git push origin HEAD:dev
-   git checkout claude/T-XXX-description   # return to your feature branch
-   git branch -d meta-T-XXX-done
-   ```
-   This ensures only the TASKS.md change reaches dev, never your feature code.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,11 +18,11 @@ Requires JDK 21. The CI workflow mirrors these commands.
 
 **⚠️ AGENTS: Debug build FAILS in this environment** (Gradle plugin resolution blocked by proxy). **IGNORE BUILD FAILURES.** Skip `./gradlew assembleDebug` entirely. Code syntax validation is sufficient. CI will handle real builds.
 
-`CHANGELOG.md` exists at the repo root. **After completing ANY work (even meta-updates), you MUST append an entry to the top of the relevant section.** 
+`CHANGELOG.md` exists at the repo root. It is maintained exclusively by the **Orchestrator** after all PRs in a wave are merged to `dev`.
 
 - **Format**: `### YYYY-MM-DD HH:MM — Short Title (Author)`
-- **Metadata**: Include origin (e.g., `Direct push to dev`) and detailed changes.
-- **Rule**: Updates to `CHANGELOG.md` are Meta-files and must be pushed directly to `dev` to prevent sync issues between parallel agents.
+- **Metadata**: Include origin (e.g., `Wave N — Tasks T-XXX, T-YYY`) and detailed changes.
+- **Rule**: Workers must **never** touch `CHANGELOG.md`. The Orchestrator writes one consolidated entry directly to `dev` after the wave completes.
 
 
 # Agent Rules & Guidelines


### PR DESCRIPTION
## Description

This change restructures the feature development workflow to simplify task tracking and eliminate direct pushes to `dev`. The key insight is that marking a task as "done" in `TASKS.md` should be part of the PR itself, not a separate isolated push after the PR is created.

**Before**: Developers created a PR, then made a separate meta-branch to push only the TASKS.md update directly to `dev`.

**After**: Developers commit the TASKS.md update on their feature branch before pushing the PR. The TASKS.md change merges with the PR, keeping all work together.

Additionally, `CHANGELOG.md` maintenance is now exclusively the Orchestrator's responsibility after all PRs in a wave merge, removing the burden from individual workers.

## Changes Made

- `.agents/workflows/feature-work.md`:
  - Moved TASKS.md update (step 6) to occur **before** the rebase and PR push
  - Removed the complex "isolated meta push" workflow (old step 9) that required a separate branch and direct `dev` push
  - Clarified that TASKS.md changes stay on the feature branch and merge with the PR
  - Removed instruction to update `CHANGELOG.md` (now Orchestrator-only)
  - Renumbered subsequent steps (7→8, 8→9)

- `CLAUDE.md`:
  - Updated `CHANGELOG.md` guidance to reflect that workers must **never** touch it
  - Clarified that the Orchestrator writes one consolidated entry directly to `dev` after the wave completes
  - Updated metadata format example to reference wave context

## Verification

- [ ] Documentation changes reviewed for clarity and consistency
- [ ] Workflow steps are logically ordered and conflict-free
- [ ] No code changes (documentation only)

## Checklist

- [ ] `PROJECT.md` updated — N/A
- [ ] `BACKLOG.md` updated — N/A
- [ ] `CHANGELOG.md` updated — N/A (intentionally not touched per new policy)
- [ ] Branch follows `claude/` or `feature/` convention — N/A (meta documentation)

https://claude.ai/code/session_01SWy7Te6fVA1SaHsYqZeuEp