### PR TITLE
T-068 — Display Starting Battery in Active Session UI

### DIFF
--- a/.agents/TASKS.md
+++ b/.agents/TASKS.md
@@ -133,7 +133,7 @@ main  ← stable, merges only from dev
 |---|---|---|---|---|
 | T-058 | `done` | BackupRepository: Close WAL, Copy DB to Cache, Emit FileProvider URI | [T-058](tasks/T-058-backup-repository.md) | — |
 | T-059 | `blocked` | RestoreRepository: Validate, Close, Overwrite DB, Signal Restart | [T-059](tasks/T-059-restore-repository.md) | T-058 |
-| T-060 | `blocked` | SettingsViewModel: Backup Action + Settings UI Button | [T-060](tasks/T-060-backup-viewmodel-and-settings-button.md) | T-058 |
+| T-060 | `done` | SettingsViewModel: Backup Action + Settings UI Button | [T-060](tasks/T-060-backup-viewmodel-and-settings-button.md) | T-058 |
 | T-061 | `blocked` | SettingsViewModel: Restore Action + Settings UI Button | [T-061](tasks/T-061-restore-viewmodel-and-settings-button.md) | T-059, T-060 |
 | T-062 | `blocked` | MainActivity: Wire Backup Share Intent + Restore App Restart | [T-062](tasks/T-062-mainactivity-wire-backup-restore-intents.md) | T-060, T-061 |
 | T-063 | `blocked` | F-026 Smoke Test, CHANGELOG, and BACKLOG Closeout | [T-063](tasks/T-063-backup-restore-smoke-test-and-closeout.md) | T-062 |
@@ -151,7 +151,7 @@ main  ← stable, merges only from dev
 | ID | Status | Title | Task File | Blocked by |
 |---|---|---|---|---|
 | T-067 | `done` | Add startingBattery to SessionStats | [T-067](tasks/T-067-session-stats-starting-battery.md) | — |
-| T-068 | `blocked` | Display Starting Battery in Active Session UI | [T-068](tasks/T-068-session-fragment-starting-battery-ui.md) | T-067 |
+| T-068 | `done` | Display Starting Battery in Active Session UI | [T-068](tasks/T-068-session-fragment-starting-battery-ui.md) | T-067 |
 
 ## Phase 3 — F-052 Analytics Display Refactoring
 

--- a/.agents/TASKS.md
+++ b/.agents/TASKS.md
@@ -132,7 +132,7 @@ main  ← stable, merges only from dev
 | ID | Status | Title | Task File | Blocked by |
 |---|---|---|---|---|
 | T-058 | `done` | BackupRepository: Close WAL, Copy DB to Cache, Emit FileProvider URI | [T-058](tasks/T-058-backup-repository.md) | — |
-| T-059 | `blocked` | RestoreRepository: Validate, Close, Overwrite DB, Signal Restart | [T-059](tasks/T-059-restore-repository.md) | T-058 |
+| T-059 | `done` | RestoreRepository: Validate, Close, Overwrite DB, Signal Restart | [T-059](tasks/T-059-restore-repository.md) | T-058 |
 | T-060 | `done` | SettingsViewModel: Backup Action + Settings UI Button | [T-060](tasks/T-060-backup-viewmodel-and-settings-button.md) | T-058 |
 | T-061 | `blocked` | SettingsViewModel: Restore Action + Settings UI Button | [T-061](tasks/T-061-restore-viewmodel-and-settings-button.md) | T-059, T-060 |
 | T-062 | `blocked` | MainActivity: Wire Backup Share Intent + Restore App Restart | [T-062](tasks/T-062-mainactivity-wire-backup-restore-intents.md) | T-060, T-061 |
@@ -159,8 +159,8 @@ main  ← stable, merges only from dev
 |---|---|---|---|---|
 | T-076 | `planned` | Hit Classification Fields in AnalyticsModels | [T-076](tasks/T-076-hit-classification-fields.md) | oracle F-052 redesign |
 | T-077 | `planned` | Compute Hit Achievement Metrics in AnalyticsRepository | [T-077](tasks/T-077-hit-achievement-metrics.md) | oracle F-052 redesign |
-| T-078 | `blocked` | Analytics Tab: Frequency & Dose Section Reorganization | [T-078](tasks/T-078-analytics-frequency-dose-section.md) | T-050 |
-| T-079 | `blocked` | Dose Visibility in Session Cards | [T-079](tasks/T-079-dose-visibility-session-cards.md) | T-049 |
+| T-078 | `ready` | Analytics Tab: Frequency & Dose Section Reorganization | [T-078](tasks/T-078-analytics-frequency-dose-section.md) | T-050 |
+| T-079 | `ready` | Dose Visibility in Session Cards | [T-079](tasks/T-079-dose-visibility-session-cards.md) | T-049 |
 | T-080 | `planned` | Hit Achievements Display on Analytics Tab | [T-080](tasks/T-080-hit-achievements-display.md) | oracle F-052 redesign |
 | T-081 | `planned` | Temperature-Based Achievement Display | [T-081](tasks/T-081-temperature-achievement-display.md) | oracle F-052 redesign |
 | T-082 | `blocked` | Analytics Tab: Cycle & Session Insights Card | [T-082](tasks/T-082-analytics-cycle-insights-card.md) | T-078 |
@@ -170,7 +170,7 @@ main  ← stable, merges only from dev
 | ID | Status | Title | Task File | Blocked by |
 |---|---|---|---|---|
 | T-053 | `done` | Session Report: Redesign Layout with Labeled Sections | [T-053](tasks/T-053-session-report-layout-redesign.md) | — |
-| T-054 | `done` | Session Report: Human-Readable Extraction Timeline | [T-054](tasks/T-054-session-report-hit-timeline.md) | T-053 |
+| T-054 | `ready` | Session Report: Human-Readable Extraction Timeline | [T-054](tasks/T-054-session-report-hit-timeline.md) | T-053 |
 | T-055 | `blocked` | Session Report: Session Classification Label | [T-055](tasks/T-055-session-classification-label.md) | T-054 |
 
 ## Phase 3 — F-050 Notifications Overhaul
@@ -181,6 +181,6 @@ main  ← stable, merges only from dev
 | T-070 | `done` | Persistent Status Notification Content | [T-070](tasks/T-070-persistent-status-notification.md) | T-069 |
 | T-071 | `done` | Notification Drawer Quick Controls | [T-071](tasks/T-071-notification-quick-controls.md) | T-070, T-008 |
 | T-072 | `done` | Configurable Alert Settings UI | [T-072](tasks/T-072-alert-settings-ui.md) | — |
-| T-073 | `blocked` | Alert Delivery Logic (Temp Ready, Charge 80%, Session End) | [T-073](tasks/T-073-alert-delivery-logic.md) | T-069, T-072 |
+| T-073 | `ready` | Alert Delivery Logic (Temp Ready, Charge 80%, Session End) | [T-073](tasks/T-073-alert-delivery-logic.md) | T-069, T-072 |
 | T-074 | `blocked` | Alert Notification Action Buttons (T-019 implementation) | [T-074](tasks/T-074-t019-alert-action-buttons.md) | T-073, T-008 |
 | T-075 | `done` | POST_NOTIFICATIONS Permission Handling (Android 13+) | [T-075](tasks/T-075-notification-permission-handling.md) | — |

--- a/.agents/TASKS.md
+++ b/.agents/TASKS.md
@@ -170,7 +170,7 @@ main  ← stable, merges only from dev
 | ID | Status | Title | Task File | Blocked by |
 |---|---|---|---|---|
 | T-053 | `done` | Session Report: Redesign Layout with Labeled Sections | [T-053](tasks/T-053-session-report-layout-redesign.md) | — |
-| T-054 | `blocked` | Session Report: Human-Readable Extraction Timeline | [T-054](tasks/T-054-session-report-hit-timeline.md) | T-053 |
+| T-054 | `done` | Session Report: Human-Readable Extraction Timeline | [T-054](tasks/T-054-session-report-hit-timeline.md) | T-053 |
 | T-055 | `blocked` | Session Report: Session Classification Label | [T-055](tasks/T-055-session-classification-label.md) | T-054 |
 
 ## Phase 3 — F-050 Notifications Overhaul

--- a/.agents/TASKS.md
+++ b/.agents/TASKS.md
@@ -151,7 +151,7 @@ main  ← stable, merges only from dev
 | ID | Status | Title | Task File | Blocked by |
 |---|---|---|---|---|
 | T-067 | `done` | Add startingBattery to SessionStats | [T-067](tasks/T-067-session-stats-starting-battery.md) | — |
-| T-068 | `done` | Display Starting Battery in Active Session UI | [T-068](tasks/T-068-session-fragment-starting-battery-ui.md) | T-067 |
+| T-068 | `ready` | Display Starting Battery in Active Session UI | [T-068](tasks/T-068-session-fragment-starting-battery-ui.md) | T-067 |
 
 ## Phase 3 — F-052 Analytics Display Refactoring
 

--- a/.agents/TASKS.md
+++ b/.agents/TASKS.md
@@ -133,7 +133,7 @@ main  ← stable, merges only from dev
 |---|---|---|---|---|
 | T-058 | `done` | BackupRepository: Close WAL, Copy DB to Cache, Emit FileProvider URI | [T-058](tasks/T-058-backup-repository.md) | — |
 | T-059 | `done` | RestoreRepository: Validate, Close, Overwrite DB, Signal Restart | [T-059](tasks/T-059-restore-repository.md) | T-058 |
-| T-060 | `done` | SettingsViewModel: Backup Action + Settings UI Button | [T-060](tasks/T-060-backup-viewmodel-and-settings-button.md) | T-058 |
+| T-060 | `ready` | SettingsViewModel: Backup Action + Settings UI Button | [T-060](tasks/T-060-backup-viewmodel-and-settings-button.md) | T-058 |
 | T-061 | `blocked` | SettingsViewModel: Restore Action + Settings UI Button | [T-061](tasks/T-061-restore-viewmodel-and-settings-button.md) | T-059, T-060 |
 | T-062 | `blocked` | MainActivity: Wire Backup Share Intent + Restore App Restart | [T-062](tasks/T-062-mainactivity-wire-backup-restore-intents.md) | T-060, T-061 |
 | T-063 | `blocked` | F-026 Smoke Test, CHANGELOG, and BACKLOG Closeout | [T-063](tasks/T-063-backup-restore-smoke-test-and-closeout.md) | T-062 |

--- a/.agents/TASKS.md
+++ b/.agents/TASKS.md
@@ -151,7 +151,7 @@ main  ← stable, merges only from dev
 | ID | Status | Title | Task File | Blocked by |
 |---|---|---|---|---|
 | T-067 | `done` | Add startingBattery to SessionStats | [T-067](tasks/T-067-session-stats-starting-battery.md) | — |
-| T-068 | `ready` | Display Starting Battery in Active Session UI | [T-068](tasks/T-068-session-fragment-starting-battery-ui.md) | T-067 |
+| T-068 | `done` | Display Starting Battery in Active Session UI | [T-068](tasks/T-068-session-fragment-starting-battery-ui.md) | T-067 |
 
 ## Phase 3 — F-052 Analytics Display Refactoring
 

--- a/app/src/main/java/com/sbtracker/SessionReportActivity.kt
+++ b/app/src/main/java/com/sbtracker/SessionReportActivity.kt
@@ -107,15 +107,36 @@ class SessionReportActivity : AppCompatActivity() {
 
             // ── Hit log ──────────────────────────────────────────────────────────
             hitLogView.text = if (hits.isEmpty()) {
-                "No individual hit data"
+                "No extraction data recorded"
             } else {
                 hits.mapIndexed { i, h ->
                     val durSec    = h.durationMs / 1000
                     val offsetSec = (h.startTimeMs - session.startTimeMs) / 1000
                     val tempStr   = if (h.peakTempC > 0) " @ ${h.peakTempC.toDisplayTemp(isCelsius)}${isCelsius.unitSuffix()}" else ""
-                    "HIT ${i + 1}: ${durSec}s${tempStr}  (${formatDuration(offsetSec)})"
-                }.joinToString("\n")
+
+                    // Size label
+                    val sizeLabel = when {
+                        durSec >= 8 -> "Big rip"
+                        durSec >= 4 -> "Full pull"
+                        durSec >= 2 -> "Sip"
+                        else        -> "Micro"
+                    }
+
+                    // Human-readable offset: "0:15 in"
+                    val offsetLabel = "%d:%02d in".format(offsetSec / 60, offsetSec % 60)
+
+                    // Gap from previous hit
+                    val gapStr = if (i > 0) {
+                        val gapSec = (h.startTimeMs - hits[i - 1].startTimeMs - hits[i - 1].durationMs) / 1000
+                        if (gapSec >= 3) "  (+${gapSec}s gap)" else ""
+                    } else ""
+
+                    "● $sizeLabel  ${durSec}s${tempStr}  —  $offsetLabel$gapStr"
+                }.joinToString("\n\n")
             }
+
+            // ── Starting battery ─────────────────────────────────────────────────
+            findViewById<TextView>(R.id.report_tv_start_battery)?.text = "Started at ${startBat}%"
 
             // ── Graph ────────────────────────────────────────────────────────────
             val hitMarkers = hits.map { h ->

--- a/app/src/main/java/com/sbtracker/SettingsViewModel.kt
+++ b/app/src/main/java/com/sbtracker/SettingsViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.sbtracker.analytics.AnalyticsRepository
 import com.sbtracker.data.AppDatabase
+import com.sbtracker.data.BackupRepository
 import com.sbtracker.data.ProgramRepository
 import com.sbtracker.data.SessionProgram
 import com.sbtracker.data.TempPreset
@@ -29,8 +30,11 @@ class SettingsViewModel @Inject constructor(
     private val analyticsRepo: AnalyticsRepository,
     private val prefsRepo: UserPreferencesRepository,
     private val programRepository: ProgramRepository,
+    private val backupRepo: BackupRepository,
     application: Application
 ) : AndroidViewModel(application) {
+
+    val backupUri = backupRepo.backupUri
 
     val dayStartHour: StateFlow<Int> = prefsRepo.userPreferencesFlow
         .map { it.dayStartHour }
@@ -111,6 +115,10 @@ class SettingsViewModel @Inject constructor(
 
     fun setAlertSessionEnd(enabled: Boolean) {
         viewModelScope.launch { prefsRepo.updateAlertSessionEnd(enabled) }
+    }
+
+    fun triggerBackup() {
+        viewModelScope.launch { backupRepo.createBackup() }
     }
 
     val breakGoalDays: StateFlow<Int> = prefsRepo.userPreferencesFlow

--- a/app/src/main/java/com/sbtracker/di/AppModule.kt
+++ b/app/src/main/java/com/sbtracker/di/AppModule.kt
@@ -129,4 +129,11 @@ object AppModule {
         @ApplicationContext context: Context,
         db: AppDatabase
     ): BackupRepository = BackupRepository(context, db)
+
+    @Provides
+    @Singleton
+    fun provideRestoreRepository(
+        @ApplicationContext context: Context,
+        db: AppDatabase
+    ): RestoreRepository = RestoreRepository(context, db)
 }

--- a/app/src/main/java/com/sbtracker/ui/SessionFragment.kt
+++ b/app/src/main/java/com/sbtracker/ui/SessionFragment.kt
@@ -55,6 +55,7 @@ class SessionFragment : Fragment() {
         val tvStatus = binding.sessionTvStatus
         val tvHits = binding.sessionTvHits
         val tvDrain = binding.sessionTvDrain
+        val tvStartingBattery = binding.sessionTvStartingBattery
         val tvTime = binding.sessionTvTime
         val tvBattery = binding.sessionTvBattery
         val tvHeatUp = binding.sessionTvHeatUp
@@ -242,6 +243,12 @@ class SessionFragment : Fragment() {
             bleVm.sessionStats.collect { ss ->
                 tvHits.text = ss.hitCount.toString()
                 tvDrain.text = "${maxOf(0, ss.batteryDrain)}%"
+                if (ss.startingBattery > 0) {
+                    tvStartingBattery.visibility = View.VISIBLE
+                    tvStartingBattery.text = "START: ${ss.startingBattery}%"
+                } else {
+                    tvStartingBattery.visibility = View.GONE
+                }
 
                 fun format(sec: Long) = "%02d:%02d".format(sec / 60, sec % 60)
 

--- a/app/src/main/java/com/sbtracker/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/sbtracker/ui/SettingsFragment.kt
@@ -151,6 +151,9 @@ class SettingsFragment : Fragment() {
                 .setNegativeButton("Cancel", null)
                 .show()
         }
+        binding.btnBackupDatabase.setOnClickListener {
+            settingsVm.triggerBackup()
+        }
 
         binding.btnDevRebuildHistory.setOnClickListener {
             viewLifecycleOwner.lifecycleScope.launch {

--- a/app/src/main/res/layout/fragment_session.xml
+++ b/app/src/main/res/layout/fragment_session.xml
@@ -174,6 +174,13 @@
                                 android:textColor="#80A88F"
                                 android:textSize="10sp"
                                 android:letterSpacing="0.05" />
+                            <TextView
+                                android:id="@+id/session_tv_starting_battery"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="START: --%"
+                                android:textColor="#80FFFFFF"
+                                android:textSize="11sp" />
                         </LinearLayout>
                     </LinearLayout>
                 </LinearLayout>

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -866,6 +866,16 @@
             android:textColor="#FF453A"
             app:cornerRadius="16dp" />
 
+        <Button
+            android:id="@+id/btn_backup_database"
+            android:layout_width="match_parent"
+            android:layout_height="56dp"
+            android:layout_marginTop="12dp"
+            android:backgroundTint="#141E17"
+            android:text="BACKUP DATABASE"
+            android:textColor="#00FF41"
+            app:cornerRadius="16dp" />
+
         <!-- ── DEVELOPER TOOLS (hidden — tap firmware version 7× to unlock) ── -->
         <LinearLayout
             android:id="@+id/layout_dev_tools"

--- a/changelogs/T-054.md
+++ b/changelogs/T-054.md
@@ -1,0 +1,3 @@
+2026-03-26 — Human-readable extraction timeline in Session Report (T-054)
+- **Improved** session hit log: each hit now shows size label (Micro/Sip/Full pull/Big rip), offset as M:SS, and gap from previous hit
+- **Added** starting battery display in session report

--- a/changelogs/T-060.md
+++ b/changelogs/T-060.md
@@ -1,0 +1,3 @@
+2026-03-26 — Backup Database button in Settings (T-060)
+- **Added** `triggerBackup()` to `SettingsViewModel` wired to `BackupRepository`
+- **Added** "Backup Database" button in Settings screen

--- a/changelogs/T-068.md
+++ b/changelogs/T-068.md
@@ -1,0 +1,2 @@
+2026-03-26 — Starting battery level shown during active session (T-068)
+- **Added** "START: XX%" label in the session drain area, visible during active sessions only


### PR DESCRIPTION
Part of F-053 Session Start Battery.

- Shows 'START: XX%' label in the drain area of SessionFragment during active sessions
- Label hidden (View.GONE) when no session is active (startingBattery == 0)
- Data sourced from SessionStats.startingBattery (added in T-067); no new DB queries