### PR TITLE
T-054 — Session Report: Human-Readable Extraction Timeline

### DIFF
--- a/.agents/TASKS.md
+++ b/.agents/TASKS.md
@@ -170,7 +170,7 @@ main  ← stable, merges only from dev
 | ID | Status | Title | Task File | Blocked by |
 |---|---|---|---|---|
 | T-053 | `done` | Session Report: Redesign Layout with Labeled Sections | [T-053](tasks/T-053-session-report-layout-redesign.md) | — |
-| T-054 | `blocked` | Session Report: Human-Readable Extraction Timeline | [T-054](tasks/T-054-session-report-hit-timeline.md) | T-053 |
+| T-054 | `done` | Session Report: Human-Readable Extraction Timeline | [T-054](tasks/T-054-session-report-hit-timeline.md) | T-053 |
 | T-055 | `blocked` | Session Report: Session Classification Label | [T-055](tasks/T-055-session-classification-label.md) | T-054 |
 
 ## Phase 3 — F-050 Notifications Overhaul

--- a/app/src/main/java/com/sbtracker/SessionReportActivity.kt
+++ b/app/src/main/java/com/sbtracker/SessionReportActivity.kt
@@ -107,15 +107,36 @@ class SessionReportActivity : AppCompatActivity() {
 
             // ── Hit log ──────────────────────────────────────────────────────────
             hitLogView.text = if (hits.isEmpty()) {
-                "No individual hit data"
+                "No extraction data recorded"
             } else {
                 hits.mapIndexed { i, h ->
                     val durSec    = h.durationMs / 1000
                     val offsetSec = (h.startTimeMs - session.startTimeMs) / 1000
                     val tempStr   = if (h.peakTempC > 0) " @ ${h.peakTempC.toDisplayTemp(isCelsius)}${isCelsius.unitSuffix()}" else ""
-                    "HIT ${i + 1}: ${durSec}s${tempStr}  (${formatDuration(offsetSec)})"
-                }.joinToString("\n")
+
+                    // Size label
+                    val sizeLabel = when {
+                        durSec >= 8 -> "Big rip"
+                        durSec >= 4 -> "Full pull"
+                        durSec >= 2 -> "Sip"
+                        else        -> "Micro"
+                    }
+
+                    // Human-readable offset: "0:15 in"
+                    val offsetLabel = "%d:%02d in".format(offsetSec / 60, offsetSec % 60)
+
+                    // Gap from previous hit
+                    val gapStr = if (i > 0) {
+                        val gapSec = (h.startTimeMs - hits[i - 1].startTimeMs - hits[i - 1].durationMs) / 1000
+                        if (gapSec >= 3) "  (+${gapSec}s gap)" else ""
+                    } else ""
+
+                    "● $sizeLabel  ${durSec}s${tempStr}  —  $offsetLabel$gapStr"
+                }.joinToString("\n\n")
             }
+
+            // ── Starting battery ─────────────────────────────────────────────────
+            findViewById<TextView>(R.id.report_tv_start_battery)?.text = "Started at ${startBat}%"
 
             // ── Graph ────────────────────────────────────────────────────────────
             val hitMarkers = hits.map { h ->

--- a/changelogs/T-054.md
+++ b/changelogs/T-054.md
@@ -1,0 +1,3 @@
+2026-03-26 — Human-readable extraction timeline in Session Report (T-054)
+- **Improved** session hit log: each hit now shows size label (Micro/Sip/Full pull/Big rip), offset as M:SS, and gap from previous hit
+- **Added** starting battery display in session report


### PR DESCRIPTION
Superseded by PR #83 (T-055), which is a strict superset containing both the T-054 hit timeline changes and the T-055 classification label. Closing to avoid merge conflict on SessionReportActivity.kt.