### PR TITLE
T-073 — Alert Delivery Logic: Per-Event Prefs + Session End Alert

### DIFF
--- a/.agents/TASKS.md
+++ b/.agents/TASKS.md
@@ -151,7 +151,7 @@ main  ← stable, merges only from dev
 | ID | Status | Title | Task File | Blocked by |
 |---|---|---|---|---|
 | T-067 | `done` | Add startingBattery to SessionStats | [T-067](tasks/T-067-session-stats-starting-battery.md) | — |
-| T-068 | `blocked` | Display Starting Battery in Active Session UI | [T-068](tasks/T-068-session-fragment-starting-battery-ui.md) | T-067 |
+| T-068 | `done` | Display Starting Battery in Active Session UI | [T-068](tasks/T-068-session-fragment-starting-battery-ui.md) | T-067 |
 
 ## Phase 3 — F-052 Analytics Display Refactoring
 


### PR DESCRIPTION
Superseded. This branch was mislabeled — it contains only a 1-line TASKS.md status update. The actual T-073 alert delivery logic is correctly bundled in PR #85 (T-074).