### PR TITLE
T-079 — Dose Visibility in Session Cards

### DIFF
--- a/.agents/TASKS.md
+++ b/.agents/TASKS.md
@@ -160,7 +160,7 @@ main  ← stable, merges only from dev
 | T-076 | `planned` | Hit Classification Fields in AnalyticsModels | [T-076](tasks/T-076-hit-classification-fields.md) | oracle F-052 redesign |
 | T-077 | `planned` | Compute Hit Achievement Metrics in AnalyticsRepository | [T-077](tasks/T-077-hit-achievement-metrics.md) | oracle F-052 redesign |
 | T-078 | `ready` | Analytics Tab: Frequency & Dose Section Reorganization | [T-078](tasks/T-078-analytics-frequency-dose-section.md) | T-050 |
-| T-079 | `ready` | Dose Visibility in Session Cards | [T-079](tasks/T-079-dose-visibility-session-cards.md) | T-049 |
+| T-079 | `done` | Dose Visibility in Session Cards | [T-079](tasks/T-079-dose-visibility-session-cards.md) | T-049 |
 | T-080 | `planned` | Hit Achievements Display on Analytics Tab | [T-080](tasks/T-080-hit-achievements-display.md) | oracle F-052 redesign |
 | T-081 | `planned` | Temperature-Based Achievement Display | [T-081](tasks/T-081-temperature-achievement-display.md) | oracle F-052 redesign |
 | T-082 | `blocked` | Analytics Tab: Cycle & Session Insights Card | [T-082](tasks/T-082-analytics-cycle-insights-card.md) | T-078 |

--- a/app/src/main/java/com/sbtracker/HistoryViewModel.kt
+++ b/app/src/main/java/com/sbtracker/HistoryViewModel.kt
@@ -135,6 +135,28 @@ class HistoryViewModel @Inject constructor(
         .map { sessions -> analyticsRepo.getSessionSummaries(sessions) }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
+    /**
+     * Maps each session ID in the current history to its [SessionMetadata].
+     * Capsule weight fallback: when [SessionMetadata.capsuleWeightGrams] is 0, the global
+     * [UserPreferences.capsuleWeightGrams] preference is substituted so adapters always
+     * receive a usable weight value.
+     */
+    val sessionMetadataMap: StateFlow<Map<Long, SessionMetadata>> =
+        combine(sessionSummaries, prefsRepo.userPreferencesFlow) { summaries, prefs ->
+            val ids = summaries.map { it.id }
+            if (ids.isEmpty()) return@combine emptyMap()
+            val rawList = withContext(Dispatchers.IO) {
+                db.sessionMetadataDao().getMetadataForSessions(ids)
+            }
+            rawList.associate { meta ->
+                val effectiveWeight = if (meta.capsuleWeightGrams == 0f)
+                    prefs.capsuleWeightGrams
+                else
+                    meta.capsuleWeightGrams
+                meta.sessionId to meta.copy(capsuleWeightGrams = effectiveWeight)
+            }
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyMap())
+
     private val allSessionSummaries: StateFlow<List<SessionSummary>> =
         db.sessionDao().observeAllSessions()
             .map { sessions -> analyticsRepo.getSessionSummaries(sessions) }

--- a/app/src/main/java/com/sbtracker/SessionHistoryAdapter.kt
+++ b/app/src/main/java/com/sbtracker/SessionHistoryAdapter.kt
@@ -9,6 +9,7 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.sbtracker.data.ChargeCycle
+import com.sbtracker.data.SessionMetadata
 import com.sbtracker.data.SessionSummary
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -34,6 +35,9 @@ class SessionHistoryAdapter(
 
     var showDeviceName: Boolean = false
 
+    /** Metadata map keyed by session ID, provided by HistoryViewModel.sessionMetadataMap. */
+    var metadataMap: Map<Long, SessionMetadata> = emptyMap()
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         val view = LayoutInflater.from(parent.context).inflate(R.layout.item_session, parent, false)
         return ViewHolder(view)
@@ -48,6 +52,7 @@ class SessionHistoryAdapter(
         private val tvSummary: TextView = view.findViewById(R.id.tv_session_summary)
         private val tvDrain: TextView = view.findViewById(R.id.tv_session_drain_badge)
         private val tvRating: TextView = view.findViewById(R.id.tv_session_rating)
+        private val tvDoseLabel: TextView = view.findViewById(R.id.tv_dose_label)
         private val vIndicator: View = view.findViewById(R.id.v_session_indicator)
 
         private val sdf = SimpleDateFormat("MMM dd, HH:mm", Locale.getDefault())
@@ -85,6 +90,15 @@ class SessionHistoryAdapter(
                 tvRating.visibility = View.GONE
             }
 
+            // Show gram dose label for capsule sessions; hide for free-pack or missing metadata.
+            val meta = metadataMap[summary.id]
+            if (meta != null && meta.isCapsule) {
+                tvDoseLabel.visibility = View.VISIBLE
+                tvDoseLabel.text = "${"%.2f".format(meta.capsuleWeightGrams)}g"
+            } else {
+                tvDoseLabel.visibility = View.GONE
+            }
+
             val indicatorColor = when {
                 summary.hitCount >= 10 -> "#FF3B30"
                 summary.hitCount >= 5  -> "#FFD60A"
@@ -110,6 +124,8 @@ class SessionHistoryAdapter(
             tvDrain.text = "+${cycle.batteryGained}%"
             tvDrain.setTextColor(Color.parseColor("#30D158"))
             tvDrain.setBackgroundResource(R.drawable.bg_badge_green)
+
+            tvDoseLabel.visibility = View.GONE
 
             vIndicator.setBackgroundColor(Color.parseColor("#44AAFF"))
 

--- a/app/src/main/res/layout/item_session.xml
+++ b/app/src/main/res/layout/item_session.xml
@@ -78,6 +78,16 @@
                 android:textSize="11sp"
                 android:visibility="gone" />
 
+            <TextView
+                android:id="@+id/tv_dose_label"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:textColor="#80A88F"
+                android:textSize="11sp"
+                android:textStyle="bold"
+                android:visibility="gone" />
+
         </LinearLayout>
 
     </LinearLayout>

--- a/changelogs/T-079.md
+++ b/changelogs/T-079.md
@@ -1,0 +1,3 @@
+2026-03-26 — Gram dose shown on capsule session cards (T-079)
+- **Added** capsule weight label (e.g. "0.10g") on session cards for capsule sessions in Sessions tab
+- Free-pack and no-metadata sessions show no gram label


### PR DESCRIPTION
Part of F-052 Analytics Display Refactoring.

- Capsule sessions now show gram weight (e.g. '0.10g') beside hit count in the Sessions tab
- Uses global capsule weight preference as fallback when per-session weight is 0
- Free-pack and sessions without metadata show no gram label