### PR TITLE
T-055 — Session Report: Session Classification Label

### DIFF
--- a/app/src/main/java/com/sbtracker/SessionReportActivity.kt
+++ b/app/src/main/java/com/sbtracker/SessionReportActivity.kt
@@ -9,6 +9,7 @@ import android.widget.EditText
 import android.widget.RatingBar
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.lifecycleScope
 import com.sbtracker.data.AppDatabase
 import com.sbtracker.data.UserPreferencesRepository
@@ -133,6 +134,28 @@ class SessionReportActivity : AppCompatActivity() {
 
                     "● $sizeLabel  ${durSec}s${tempStr}  —  $offsetLabel$gapStr"
                 }.joinToString("\n\n")
+            }
+
+            // ── Session classification ────────────────────────────────────────────
+            val durationMin = durationMs / 60_000.0
+            val hitCount    = hitStats.hitCount
+            val classLabel  = when {
+                durationMin < 3  && hitCount <= 3  -> "Quick Sip"
+                durationMin < 5  && hitCount <= 6  -> "Light Session"
+                durationMin < 10 && hitCount <= 12 -> "Standard Session"
+                durationMin < 15                   -> "Heavy Session"
+                else                               -> "Marathon"
+            }
+            val classColor = when (classLabel) {
+                "Quick Sip"        -> ContextCompat.getColor(this, R.color.color_gray_mid)
+                "Light Session"    -> ContextCompat.getColor(this, R.color.color_green)
+                "Standard Session" -> ContextCompat.getColor(this, R.color.color_blue)
+                "Heavy Session"    -> ContextCompat.getColor(this, R.color.color_orange)
+                else               -> ContextCompat.getColor(this, R.color.color_red)
+            }
+            findViewById<TextView>(R.id.report_tv_session_class)?.apply {
+                text = classLabel
+                setTextColor(classColor)
             }
 
             // ── Starting battery ─────────────────────────────────────────────────

--- a/changelogs/T-055.md
+++ b/changelogs/T-055.md
@@ -1,0 +1,2 @@
+2026-03-26 — Session classification label in Session Report (T-055)
+- **Added** session type label (Quick Sip / Light Session / Standard Session / Heavy Session / Marathon) based on duration and hit count in SessionReportActivity


### PR DESCRIPTION
Part of F-054 Session Page Complete Redesign.

- Adds 'Quick Sip / Light Session / Standard Session / Heavy Session / Marathon' classification label to session report
- Classification based on session duration (minutes) and hit count, with color coding (gray → green → blue → orange → red)
- Also includes T-054 hit timeline changes (human-readable extraction timeline) since T-054 branch is not yet in dev
- Completes the F-054 session report redesign trilogy (T-053 layout → T-054 timeline → T-055 label)