### PR TITLE
T-061 — SettingsViewModel: Restore Action + Settings UI Button

### DIFF
--- a/.agents/TASKS.md
+++ b/.agents/TASKS.md
@@ -134,7 +134,7 @@ main  ← stable, merges only from dev
 | T-058 | `done` | BackupRepository: Close WAL, Copy DB to Cache, Emit FileProvider URI | [T-058](tasks/T-058-backup-repository.md) | — |
 | T-059 | `done` | RestoreRepository: Validate, Close, Overwrite DB, Signal Restart | [T-059](tasks/T-059-restore-repository.md) | T-058 |
 | T-060 | `done` | SettingsViewModel: Backup Action + Settings UI Button | [T-060](tasks/T-060-backup-viewmodel-and-settings-button.md) | T-058 |
-| T-061 | `blocked` | SettingsViewModel: Restore Action + Settings UI Button | [T-061](tasks/T-061-restore-viewmodel-and-settings-button.md) | T-059, T-060 |
+| T-061 | `done` | SettingsViewModel: Restore Action + Settings UI Button | [T-061](tasks/T-061-restore-viewmodel-and-settings-button.md) | T-059, T-060 |
 | T-062 | `blocked` | MainActivity: Wire Backup Share Intent + Restore App Restart | [T-062](tasks/T-062-mainactivity-wire-backup-restore-intents.md) | T-060, T-061 |
 | T-063 | `blocked` | F-026 Smoke Test, CHANGELOG, and BACKLOG Closeout | [T-063](tasks/T-063-backup-restore-smoke-test-and-closeout.md) | T-062 |
 

--- a/app/src/main/java/com/sbtracker/SettingsViewModel.kt
+++ b/app/src/main/java/com/sbtracker/SettingsViewModel.kt
@@ -1,13 +1,14 @@
 package com.sbtracker
 
 import android.app.Application
-import android.content.Context
+import android.net.Uri
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.sbtracker.analytics.AnalyticsRepository
 import com.sbtracker.data.AppDatabase
 import com.sbtracker.data.BackupRepository
 import com.sbtracker.data.ProgramRepository
+import com.sbtracker.data.RestoreRepository
 import com.sbtracker.data.SessionProgram
 import com.sbtracker.data.TempPreset
 import com.sbtracker.data.UserPreferencesRepository
@@ -17,7 +18,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 /**
@@ -31,10 +31,14 @@ class SettingsViewModel @Inject constructor(
     private val prefsRepo: UserPreferencesRepository,
     private val programRepository: ProgramRepository,
     private val backupRepo: BackupRepository,
+    private val restoreRepo: RestoreRepository,
     application: Application
 ) : AndroidViewModel(application) {
 
     val backupUri = backupRepo.backupUri
+
+    val restoreResult = restoreRepo.restoreResult
+
 
     val dayStartHour: StateFlow<Int> = prefsRepo.userPreferencesFlow
         .map { it.dayStartHour }
@@ -120,6 +124,11 @@ class SettingsViewModel @Inject constructor(
     fun triggerBackup() {
         viewModelScope.launch { backupRepo.createBackup() }
     }
+
+    fun triggerRestore(uri: Uri) {
+        viewModelScope.launch { restoreRepo.restoreFrom(uri) }
+    }
+
 
     val breakGoalDays: StateFlow<Int> = prefsRepo.userPreferencesFlow
         .map { it.breakGoalDays }

--- a/app/src/main/java/com/sbtracker/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/sbtracker/ui/SettingsFragment.kt
@@ -1,6 +1,7 @@
 package com.sbtracker.ui
 
 import android.content.Intent
+import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -9,6 +10,7 @@ import android.view.ViewGroup
 import android.widget.Button
 import android.widget.SeekBar
 import android.widget.TextView
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.widget.SwitchCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
@@ -16,6 +18,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.sbtracker.*
+import com.sbtracker.data.RestoreResult
 import com.sbtracker.databinding.FragmentSettingsBinding
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -28,6 +31,12 @@ class SettingsFragment : Fragment() {
     private val historyVm: HistoryViewModel by activityViewModels()
     private var _binding: FragmentSettingsBinding? = null
     private val binding get() = _binding!!
+
+    private val restoreLauncher = registerForActivityResult(
+        ActivityResultContracts.OpenDocument()
+    ) { uri: Uri? ->
+        uri?.let { settingsVm.triggerRestore(it) }
+    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentSettingsBinding.inflate(inflater, container, false)
@@ -154,6 +163,23 @@ class SettingsFragment : Fragment() {
         binding.btnBackupDatabase.setOnClickListener {
             settingsVm.triggerBackup()
         }
+        binding.btnRestoreDatabase.setOnClickListener {
+            restoreLauncher.launch(arrayOf("*/*"))
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            settingsVm.restoreResult.collect { result ->
+                when (result) {
+                    is RestoreResult.Success -> android.widget.Toast.makeText(
+                        requireContext(), "Restore complete. Restarting…", android.widget.Toast.LENGTH_SHORT
+                    ).show()
+                    is RestoreResult.Failure -> android.widget.Toast.makeText(
+                        requireContext(), result.reason, android.widget.Toast.LENGTH_LONG
+                    ).show()
+                }
+            }
+        }
+
 
         binding.btnDevRebuildHistory.setOnClickListener {
             viewLifecycleOwner.lifecycleScope.launch {

--- a/changelogs/T-061.md
+++ b/changelogs/T-061.md
@@ -1,0 +1,4 @@
+2026-03-26 — Restore Database button in Settings (T-061)
+- **Added** `triggerRestore(uri)` to `SettingsViewModel` wired to `RestoreRepository`
+- **Added** "Restore Database" button in Settings screen with system file-picker launcher
+- Toast shown on success ("Restore complete. Restarting…") and failure (descriptive reason)


### PR DESCRIPTION
Part of F-026 Data Backup/Restore.

- `SettingsViewModel.triggerRestore(uri)` delegates to `RestoreRepository.restoreFrom(uri)`
- `SettingsViewModel.restoreResult` exposes `RestoreResult` SharedFlow
- 'Restore Database' button in SettingsFragment opens system file picker
- Toast shown on success/failure; actual app restart handled in MainActivity (T-062)

Also applies T-060's backup button wiring (not yet merged to dev).

Unblocks T-062.