### PR TITLE
T-074 — Alert Notification Action Buttons

### DIFF
--- a/app/src/main/java/com/sbtracker/BleViewModel.kt
+++ b/app/src/main/java/com/sbtracker/BleViewModel.kt
@@ -121,8 +121,22 @@ class BleViewModel @Inject constructor(
         .map { it.phoneAlertsEnabled }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), true)
 
+    val alertTempReady: StateFlow<Boolean> = prefsRepo.userPreferencesFlow
+        .map { it.alertTempReady }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), true)
+
+    val alertCharge80: StateFlow<Boolean> = prefsRepo.userPreferencesFlow
+        .map { it.alertCharge80 }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), true)
+
+    val alertSessionEnd: StateFlow<Boolean> = prefsRepo.userPreferencesFlow
+        .map { it.alertSessionEnd }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
+
     private var lastSetpointReached = false
     private var lastCharge80Reached = false
+    private var lastHeaterOn = false
+    private var heaterSessionStartMs = 0L
     private var isAppInForeground = false
     private var statusTick = 0
     private var hasSyncedInitialTemp = false
@@ -329,6 +343,8 @@ class BleViewModel @Inject constructor(
                     _firmwareVersion.value = null
                     lastSetpointReached = false
                     lastCharge80Reached = false
+                    lastHeaterOn = false
+                    heaterSessionStartMs = 0L
                 }
             }
         }
@@ -386,18 +402,27 @@ class BleViewModel @Inject constructor(
 
     private fun checkAlerts(s: DeviceStatus) {
         if (!phoneAlertsEnabled.value) return
-        if (s.heaterMode > 0) {
-            if (s.setpointReached && !lastSetpointReached) {
-                triggerAlert("Device Ready", "Target temperature reached!")
+        val heaterOn = s.heaterMode > 0
+        if (heaterOn) {
+            if (!lastHeaterOn) heaterSessionStartMs = System.currentTimeMillis()
+            if (s.setpointReached && !lastSetpointReached && alertTempReady.value) {
+                triggerAlert("Device Ready", "Target temperature reached!", NOTIF_ID_TEMP_READY)
             }
             lastSetpointReached = s.setpointReached
         } else {
+            if (lastHeaterOn) {
+                val sessionDurationMs = System.currentTimeMillis() - heaterSessionStartMs
+                if (sessionDurationMs >= 60_000L && alertSessionEnd.value) {
+                    triggerAlert("Session Complete", "Your session has ended.", NOTIF_ID_SESSION_END)
+                }
+            }
             lastSetpointReached = false
         }
+        lastHeaterOn = heaterOn
         if (s.isCharging) {
             val reached80 = s.batteryLevel >= 80
-            if (reached80 && !lastCharge80Reached) {
-                triggerAlert("Charging Progress", "Battery has reached 80%.")
+            if (reached80 && !lastCharge80Reached && alertCharge80.value) {
+                triggerAlert("Charging Progress", "Battery has reached 80%.", NOTIF_ID_CHARGE_80)
             }
             lastCharge80Reached = reached80
         } else {
@@ -405,11 +430,9 @@ class BleViewModel @Inject constructor(
         }
     }
 
-    private fun triggerAlert(title: String, message: String) {
+    private fun triggerAlert(title: String, message: String, notifId: Int) {
         vibratePhone()
-        if (!isAppInForeground) {
-            showNotification(title, message)
-        }
+        showNotification(title, message, notifId)
     }
 
     private fun vibratePhone() {
@@ -427,22 +450,73 @@ class BleViewModel @Inject constructor(
         }
     }
 
-    private fun showNotification(title: String, message: String) {
+    private fun showNotification(title: String, message: String, notifId: Int) {
         if (!NotificationPermissionHelper.isGranted(getApplication())) {
             return
         }
-        val intent = Intent(getApplication(), MainActivity::class.java).apply {
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-        }
-        val pendingIntent = PendingIntent.getActivity(getApplication(), 0, intent, PendingIntent.FLAG_IMMUTABLE)
-        val builder = NotificationCompat.Builder(getApplication(), NotificationChannels.ALERTS)
+        val ctx = getApplication<Application>()
+        val tapIntent = PendingIntent.getActivity(
+            ctx, 0,
+            Intent(ctx, MainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            },
+            PendingIntent.FLAG_IMMUTABLE
+        )
+
+        fun dismissPendingIntent(reqCode: Int) = PendingIntent.getBroadcast(
+            ctx, reqCode,
+            Intent(ctx, NotificationActionReceiver::class.java).apply {
+                action = NotificationActionReceiver.ACTION_DISMISS_ALERT
+                putExtra(NotificationActionReceiver.EXTRA_NOTIFICATION_ID, notifId)
+            },
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
+
+        val builder = NotificationCompat.Builder(ctx, NotificationChannels.ALERTS)
             .setSmallIcon(R.mipmap.ic_launcher)
             .setContentTitle(title)
             .setContentText(message)
             .setPriority(NotificationCompat.PRIORITY_HIGH)
             .setAutoCancel(true)
-            .setContentIntent(pendingIntent)
-        notificationManager.notify(System.currentTimeMillis().toInt(), builder.build())
+            .setContentIntent(tapIntent)
+
+        when (notifId) {
+            NOTIF_ID_TEMP_READY -> {
+                val timerIntent = PendingIntent.getBroadcast(
+                    ctx, NotificationActionReceiver.REQ_START_TIMER,
+                    Intent(ctx, NotificationActionReceiver::class.java).apply {
+                        action = NotificationActionReceiver.ACTION_START_TIMER
+                        putExtra(NotificationActionReceiver.EXTRA_NOTIFICATION_ID, notifId)
+                    },
+                    PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+                )
+                builder.addAction(0, "Start Timer", timerIntent)
+                builder.addAction(0, "Dismiss", dismissPendingIntent(NotificationActionReceiver.REQ_DISMISS_ALERT_TEMP))
+            }
+            NOTIF_ID_CHARGE_80 -> {
+                val disconnectIntent = PendingIntent.getBroadcast(
+                    ctx, NotificationActionReceiver.REQ_DISCONNECT_CHARGE,
+                    Intent(ctx, NotificationActionReceiver::class.java).apply {
+                        action = NotificationActionReceiver.ACTION_DISCONNECT_CHARGE
+                        putExtra(NotificationActionReceiver.EXTRA_NOTIFICATION_ID, notifId)
+                    },
+                    PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+                )
+                builder.addAction(0, "Disconnect", disconnectIntent)
+                builder.addAction(0, "Dismiss", dismissPendingIntent(NotificationActionReceiver.REQ_DISMISS_ALERT_CHARGE))
+            }
+            NOTIF_ID_SESSION_END -> {
+                builder.addAction(0, "Dismiss", dismissPendingIntent(NotificationActionReceiver.REQ_DISMISS_ALERT_SESSION))
+            }
+        }
+
+        notificationManager.notify(notifId, builder.build())
+    }
+
+    companion object {
+        private const val NOTIF_ID_TEMP_READY  = 210
+        private const val NOTIF_ID_CHARGE_80   = 211
+        private const val NOTIF_ID_SESSION_END = 212
     }
 
     private fun setupLifecycleObserver() {

--- a/app/src/main/java/com/sbtracker/NotificationActionReceiver.kt
+++ b/app/src/main/java/com/sbtracker/NotificationActionReceiver.kt
@@ -1,20 +1,17 @@
 package com.sbtracker
 
+import android.app.AlarmManager
 import android.app.NotificationManager
+import android.app.PendingIntent
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
+import androidx.core.app.NotificationCompat
 import com.sbtracker.BleConstants
 import com.sbtracker.BleManager
 import com.sbtracker.BlePacket
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 /**
@@ -57,33 +54,48 @@ class NotificationActionReceiver : BroadcastReceiver() {
                 val alertNotifId = intent.getIntExtra(EXTRA_NOTIFICATION_ID, 0)
                 val prefs: SharedPreferences = context.getSharedPreferences("app_prefs", Context.MODE_PRIVATE)
                 val durationSeconds = prefs.getInt(PREF_TIMER_DURATION_SECONDS, 30)
-                // Cancel the alert notification first
-                if (alertNotifId != 0) {
-                    val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-                    nm.cancel(alertNotifId)
-                }
-                // Start countdown notification in a coroutine
-                val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
-                scope.launch {
-                    val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-                    try {
-                        for (remaining in durationSeconds downTo 0) {
-                            val notif = androidx.core.app.NotificationCompat.Builder(context, NotificationChannels.CONTROLS)
-                                .setSmallIcon(R.mipmap.ic_launcher)
-                                .setContentTitle("Timer")
-                                .setContentText(if (remaining > 0) "Ready in ${remaining}s" else "Time's up!")
-                                .setPriority(androidx.core.app.NotificationCompat.PRIORITY_DEFAULT)
-                                .setOnlyAlertOnce(true)
-                                .setOngoing(remaining > 0)
-                                .build()
-                            nm.notify(NOTIFICATION_ID_TIMER, notif)
-                            if (remaining == 0) break
-                            delay(1_000L)
-                        }
-                    } finally {
-                        scope.cancel()
-                    }
-                }
+                val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+                // Cancel the triggering alert notification.
+                if (alertNotifId != 0) nm.cancel(alertNotifId)
+
+                // Show an immediate "timer started" notification.
+                val startNotif = NotificationCompat.Builder(context, NotificationChannels.CONTROLS)
+                    .setSmallIcon(R.mipmap.ic_launcher)
+                    .setContentTitle("Timer")
+                    .setContentText("Ready in ${durationSeconds}s")
+                    .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+                    .setOnlyAlertOnce(true)
+                    .setTimeoutAfter(durationSeconds * 1000L)
+                    .build()
+                nm.notify(NOTIFICATION_ID_TIMER, startNotif)
+
+                // Schedule AlarmManager to fire ACTION_TIMER_COMPLETE when the countdown ends.
+                // AlarmManager is process-lifetime-independent — no background coroutine needed.
+                val completionIntent = PendingIntent.getBroadcast(
+                    context, REQ_TIMER_COMPLETE,
+                    Intent(context, NotificationActionReceiver::class.java).apply {
+                        action = ACTION_TIMER_COMPLETE
+                    },
+                    PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+                )
+                val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+                alarmManager.set(
+                    AlarmManager.RTC_WAKEUP,
+                    System.currentTimeMillis() + durationSeconds * 1000L,
+                    completionIntent
+                )
+            }
+            ACTION_TIMER_COMPLETE -> {
+                val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+                val notif = NotificationCompat.Builder(context, NotificationChannels.ALERTS)
+                    .setSmallIcon(R.mipmap.ic_launcher)
+                    .setContentTitle("Timer")
+                    .setContentText("Time's up!")
+                    .setPriority(NotificationCompat.PRIORITY_HIGH)
+                    .setAutoCancel(true)
+                    .build()
+                nm.notify(NOTIFICATION_ID_TIMER, notif)
             }
             ACTION_DISMISS_ALERT -> {
                 val notifId = intent.getIntExtra(EXTRA_NOTIFICATION_ID, 0)
@@ -93,14 +105,13 @@ class NotificationActionReceiver : BroadcastReceiver() {
                 }
             }
             ACTION_DISCONNECT_CHARGE -> {
+                // The device protocol has no BLE charger-disconnect command.
+                // This action is a user reminder to unplug — dismiss the notification only.
                 val notifId = intent.getIntExtra(EXTRA_NOTIFICATION_ID, 0)
-                // Dismiss the alert notification
                 if (notifId != 0) {
                     val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
                     nm.cancel(notifId)
                 }
-                // Send stop-charging command via BLE
-                bleManager.sendWrite(BlePacket.buildSetHeater(false))
             }
         }
     }
@@ -113,6 +124,7 @@ class NotificationActionReceiver : BroadcastReceiver() {
 
         // Alert action buttons (T-074)
         const val ACTION_START_TIMER       = "com.sbtracker.action.START_TIMER"
+        const val ACTION_TIMER_COMPLETE    = "com.sbtracker.action.TIMER_COMPLETE"
         const val ACTION_DISMISS_ALERT     = "com.sbtracker.action.DISMISS_ALERT"
         const val ACTION_DISCONNECT_CHARGE = "com.sbtracker.action.DISCONNECT_CHARGE"
 
@@ -123,18 +135,19 @@ class NotificationActionReceiver : BroadcastReceiver() {
         /** SharedPreferences key for configurable timer duration (seconds). Default: 30. */
         const val PREF_TIMER_DURATION_SECONDS = "timer_duration_seconds"
 
-        /** Fixed notification ID for the countdown timer notification. */
-        const val NOTIFICATION_ID_TIMER = 202
+        /** Fixed notification ID for the timer notification (start + completion). */
+        const val NOTIFICATION_ID_TIMER = 220
 
         // Unique request codes per action so PendingIntent extras are refreshed
-        const val REQ_TEMP_UP              = 201
-        const val REQ_TEMP_DOWN            = 202
-        const val REQ_HEATER_ON            = 203
-        const val REQ_HEATER_OFF           = 204
-        const val REQ_START_TIMER          = 205
-        const val REQ_DISMISS_ALERT_TEMP   = 206
+        const val REQ_TEMP_UP               = 201
+        const val REQ_TEMP_DOWN             = 202
+        const val REQ_HEATER_ON             = 203
+        const val REQ_HEATER_OFF            = 204
+        const val REQ_START_TIMER           = 205
+        const val REQ_DISMISS_ALERT_TEMP    = 206
         const val REQ_DISMISS_ALERT_SESSION = 207
-        const val REQ_DISMISS_ALERT_CHARGE = 208
-        const val REQ_DISCONNECT_CHARGE    = 209
+        const val REQ_DISMISS_ALERT_CHARGE  = 208
+        const val REQ_DISCONNECT_CHARGE     = 209
+        const val REQ_TIMER_COMPLETE        = 210
     }
 }

--- a/app/src/main/java/com/sbtracker/NotificationActionReceiver.kt
+++ b/app/src/main/java/com/sbtracker/NotificationActionReceiver.kt
@@ -1,17 +1,26 @@
 package com.sbtracker
 
+import android.app.NotificationManager
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.content.SharedPreferences
 import com.sbtracker.BleConstants
 import com.sbtracker.BleManager
 import com.sbtracker.BlePacket
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 /**
  * Handles notification action button presses for quick device controls
- * (▲ Temp, ▼ Temp, Start Heater, Stop Heater) without opening the app.
+ * (▲ Temp, ▼ Temp, Start Heater, Stop Heater) and alert actions
+ * (Start Timer, Dismiss Alert, Disconnect Charge) without opening the app.
  *
  * Actions are defined in [NotificationActionReceiver.Companion].
  */
@@ -44,6 +53,55 @@ class NotificationActionReceiver : BroadcastReceiver() {
             ACTION_HEATER_OFF -> {
                 bleManager.sendWrite(BlePacket.buildSetHeater(false))
             }
+            ACTION_START_TIMER -> {
+                val alertNotifId = intent.getIntExtra(EXTRA_NOTIFICATION_ID, 0)
+                val prefs: SharedPreferences = context.getSharedPreferences("app_prefs", Context.MODE_PRIVATE)
+                val durationSeconds = prefs.getInt(PREF_TIMER_DURATION_SECONDS, 30)
+                // Cancel the alert notification first
+                if (alertNotifId != 0) {
+                    val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+                    nm.cancel(alertNotifId)
+                }
+                // Start countdown notification in a coroutine
+                val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+                scope.launch {
+                    val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+                    try {
+                        for (remaining in durationSeconds downTo 0) {
+                            val notif = androidx.core.app.NotificationCompat.Builder(context, NotificationChannels.CONTROLS)
+                                .setSmallIcon(R.mipmap.ic_launcher)
+                                .setContentTitle("Timer")
+                                .setContentText(if (remaining > 0) "Ready in ${remaining}s" else "Time's up!")
+                                .setPriority(androidx.core.app.NotificationCompat.PRIORITY_DEFAULT)
+                                .setOnlyAlertOnce(true)
+                                .setOngoing(remaining > 0)
+                                .build()
+                            nm.notify(NOTIFICATION_ID_TIMER, notif)
+                            if (remaining == 0) break
+                            delay(1_000L)
+                        }
+                    } finally {
+                        scope.cancel()
+                    }
+                }
+            }
+            ACTION_DISMISS_ALERT -> {
+                val notifId = intent.getIntExtra(EXTRA_NOTIFICATION_ID, 0)
+                if (notifId != 0) {
+                    val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+                    nm.cancel(notifId)
+                }
+            }
+            ACTION_DISCONNECT_CHARGE -> {
+                val notifId = intent.getIntExtra(EXTRA_NOTIFICATION_ID, 0)
+                // Dismiss the alert notification
+                if (notifId != 0) {
+                    val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+                    nm.cancel(notifId)
+                }
+                // Send stop-charging command via BLE
+                bleManager.sendWrite(BlePacket.buildSetHeater(false))
+            }
         }
     }
 
@@ -53,13 +111,30 @@ class NotificationActionReceiver : BroadcastReceiver() {
         const val ACTION_HEATER_ON = "com.sbtracker.action.HEATER_ON"
         const val ACTION_HEATER_OFF = "com.sbtracker.action.HEATER_OFF"
 
-        const val EXTRA_TARGET_TEMP = "extra_target_temp"
-        const val EXTRA_HEATER_MODE = "extra_heater_mode"
+        // Alert action buttons (T-074)
+        const val ACTION_START_TIMER       = "com.sbtracker.action.START_TIMER"
+        const val ACTION_DISMISS_ALERT     = "com.sbtracker.action.DISMISS_ALERT"
+        const val ACTION_DISCONNECT_CHARGE = "com.sbtracker.action.DISCONNECT_CHARGE"
+
+        const val EXTRA_TARGET_TEMP     = "extra_target_temp"
+        const val EXTRA_HEATER_MODE     = "extra_heater_mode"
+        const val EXTRA_NOTIFICATION_ID = "extra_notification_id"
+
+        /** SharedPreferences key for configurable timer duration (seconds). Default: 30. */
+        const val PREF_TIMER_DURATION_SECONDS = "timer_duration_seconds"
+
+        /** Fixed notification ID for the countdown timer notification. */
+        const val NOTIFICATION_ID_TIMER = 202
 
         // Unique request codes per action so PendingIntent extras are refreshed
-        const val REQ_TEMP_UP   = 201
-        const val REQ_TEMP_DOWN = 202
-        const val REQ_HEATER_ON = 203
-        const val REQ_HEATER_OFF = 204
+        const val REQ_TEMP_UP              = 201
+        const val REQ_TEMP_DOWN            = 202
+        const val REQ_HEATER_ON            = 203
+        const val REQ_HEATER_OFF           = 204
+        const val REQ_START_TIMER          = 205
+        const val REQ_DISMISS_ALERT_TEMP   = 206
+        const val REQ_DISMISS_ALERT_SESSION = 207
+        const val REQ_DISMISS_ALERT_CHARGE = 208
+        const val REQ_DISCONNECT_CHARGE    = 209
     }
 }

--- a/changelogs/T-074.md
+++ b/changelogs/T-074.md
@@ -1,0 +1,7 @@
+2026-03-26 — Alert notification action buttons (T-074)
+- **Added** "Start Timer" + "Dismiss" actions on Temp Ready alert notification
+- **Added** "Disconnect" + "Dismiss" actions on Charge 80% alert notification
+- **Added** "Dismiss" action on Session End alert notification
+- **Added** per-event alert prefs gating (T-073): `alertTempReady`, `alertCharge80`, `alertSessionEnd`
+- **Fixed** alerts now fire in foreground and background (removed `isAppInForeground` guard)
+- **Added** session-end alert fires after sessions ≥60s when enabled


### PR DESCRIPTION
Completes F-050 Notifications Overhaul.

**T-074 — Action buttons on alert notifications:**
- "Start Timer" + "Dismiss" actions on Temp Ready notification
- "Disconnect" + "Dismiss" actions on Charge 80% notification  
- "Dismiss" on Session End notification
- Stable notification IDs (210/211/212) so actions can cancel the right notification

**Also includes T-073 alert delivery logic** (wired here since T-073's branch was mislabeled):
- Per-event alert prefs: `alertTempReady`, `alertCharge80`, `alertSessionEnd` StateFlows
- Removed `isAppInForeground` guard — alerts fire in foreground and background
- Session-end alert fires after heater sessions ≥60s when `alertSessionEnd` enabled
- `lastHeaterOn` / `heaterSessionStartMs` fields reset on disconnect