### PR TITLE
T-062 — MainActivity: Wire Backup Share Intent + Restore App Restart

### DIFF
--- a/.agents/TASKS.md
+++ b/.agents/TASKS.md
@@ -79,6 +79,17 @@ main  ← stable, merges only from dev
 | T-040 | `done` | Enhance Heat-up Estimation | [T-040](tasks/T-040-enhance-heat-up-estimation.md) | — |
 | T-041 | `done` | Wire Enhanced Heat-up Estimation | [T-041](tasks/T-041-wire-enhanced-heat-up-estimation.md) | T-040 |
 
+## Phase 3 — F-026 Data Backup/Restore
+
+| ID | Status | Title | Task File | Blocked by |
+|---|---|---|---|---|
+| T-058 | `done` | Backup Repository | [T-058](tasks/T-058-backup-repository.md) | — |
+| T-059 | `done` | Restore Repository | [T-059](tasks/T-059-restore-repository.md) | T-058 |
+| T-060 | `done` | Backup Settings UI | [T-060](tasks/T-060-backup-settings-ui.md) | T-058 |
+| T-061 | `done` | Restore Settings UI | [T-061](tasks/T-061-restore-viewmodel-and-settings-button.md) | T-059 |
+| T-062 | `done` | MainActivity: Wire Backup Share Intent + Restore App Restart | [T-062](tasks/T-062-mainactivity-wire-backup-restore-intents.md) | T-060, T-061 |
+| T-063 | `blocked` | Backup/Restore Smoke Test & Closeout | [T-063](tasks/T-063-backup-restore-smoke-test-and-closeout.md) | T-062 |
+
 ## Phase 3 — Release Readiness
 
 | ID | Status | Title | Task File | Blocked by |

--- a/app/src/main/java/com/sbtracker/MainActivity.kt
+++ b/app/src/main/java/com/sbtracker/MainActivity.kt
@@ -26,6 +26,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.RecyclerView
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import androidx.viewpager2.widget.ViewPager2
+import com.sbtracker.data.RestoreResult
 import com.sbtracker.data.SessionSummary
 import com.sbtracker.databinding.ActivityMainPagedBinding
 import com.sbtracker.ui.LandingFragment
@@ -197,6 +198,32 @@ class MainActivity : AppCompatActivity() {
                     addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
                 }
                 startActivity(Intent.createChooser(intent, "Export History"))
+            }
+        }
+
+        // Handle DB backup share
+        lifecycleScope.launch {
+            settingsVm.backupUri.collect { uri ->
+                val intent = Intent(Intent.ACTION_SEND).apply {
+                    type = "application/octet-stream"
+                    putExtra(Intent.EXTRA_STREAM, uri)
+                    addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                }
+                startActivity(Intent.createChooser(intent, "Save Database Backup"))
+            }
+        }
+
+        // Handle DB restore completion
+        lifecycleScope.launch {
+            settingsVm.restoreResult.collect { result ->
+                if (result is RestoreResult.Success) {
+                    // Hard-restart so Room reopens the freshly restored database.
+                    val restart = Intent(this@MainActivity, MainActivity::class.java)
+                    restart.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+                    startActivity(restart)
+                    android.os.Process.killProcess(android.os.Process.myPid())
+                }
+                // Failure Toasts are already shown in SettingsFragment (T-061).
             }
         }
     }

--- a/changelogs/T-062.md
+++ b/changelogs/T-062.md
@@ -1,0 +1,3 @@
+2026-03-26 — MainActivity wires backup share intent and restore restart (T-062)
+- **Added** backup share intent observer in MainActivity: fires OS share sheet when backup URI emitted
+- **Added** restore success observer: hard-restarts app via startActivity + killProcess so Room reopens cleanly


### PR DESCRIPTION
Final wiring for F-026 Data Backup/Restore.

- Observes `settingsVm.backupUri` → fires `ACTION_SEND` share chooser with `application/octet-stream`
- Observes `settingsVm.restoreResult` → on Success, clears activity stack and kills process so Room reopens the restored DB
- Failure Toasts are already shown in SettingsFragment (T-061)

Unblocks T-063 (closeout).