### PR TITLE
Oracle: Unify agent rules — eliminate merge conflict root causes

### DIFF
--- a/.agents/WORKFLOW_ENFORCEMENT.md
+++ b/.agents/WORKFLOW_ENFORCEMENT.md
@@ -50,21 +50,21 @@ git add <changed files>
 git commit -m "T-XXX: description"
 ```
 
-**4. Update CHANGELOG.md** (on your branch)
+**6. Drop a changelog fragment**
 ```bash
-# Edit CHANGELOG.md: add one line under [Unreleased]
-git add CHANGELOG.md
-git commit -m "docs: T-XXX changelog"
+# Create changelogs/T-XXX.md with a brief description
+git add changelogs/T-XXX.md
+git commit -m "docs: T-XXX changelog fragment"
 ```
 
-**5. Rebase & push**
+**7. Rebase & push**
 ```bash
 git fetch origin dev
 git rebase origin/dev           # Ensure clean history
 git push -u origin claude/T-XXX-description
 ```
 
-**6. Create PR** (target `dev`, never `main`)
+**8. Create PR** (target `dev`, never `main`)
 ```bash
 # Use mcp__github__create_pull_request:
 # - owner: 0022111
@@ -74,36 +74,25 @@ git push -u origin claude/T-XXX-description
 # - title: T-XXX — Task Title
 ```
 
-**7. Mark task done** (isolated meta push)
-```bash
-git fetch origin dev
-git checkout -b meta-T-XXX-done origin/dev
-
-# Edit .agents/TASKS.md: change status to `done`
-git add .agents/TASKS.md
-git commit -m "meta: T-XXX done"
-git push origin HEAD:dev        # Push only TASKS.md to dev
-
-git checkout claude/T-XXX-description
-git branch -d meta-T-XXX-done
-```
+**Done.** The Orchestrator handles TASKS.md, BACKLOG.md, and CHANGELOG.md.
 
 ---
 
-## Meta-files (Allowed for Direct Push to `dev`)
+## Meta-files (Restricted — Orchestrator/Planner Only)
 
-These files can be pushed directly to `dev` *after* their associated PR is open:
+These files are the #1 source of merge conflicts. **Workers must never edit them.**
 
-- `.agents/TASKS.md` (mark tasks `done` after PR merges)
-- `CHANGELOG.md` (append entry on feature branch, then pushed via PR; only direct push if orchestrator syncing)
-- `BACKLOG.md` (planner updates before decomposing into tasks; sync to dev directly)
-- `.agents/tasks/T-*.md` (new task files; direct push after creation)
-- `AGENT_INFO.md`, `CLAUDE.md` (agent instruction updates; direct push)
+| File | Who May Edit | When |
+|---|---|---|
+| `.agents/TASKS.md` | Orchestrator | After PR merges |
+| `CHANGELOG.md` | Orchestrator | At release time (merge `changelogs/` fragments) |
+| `BACKLOG.md` | Orchestrator / Planner | Status sync, new items |
+| `.agents/tasks/T-*.md` | Planner | Task creation |
+| `AGENT_INFO.md`, `CLAUDE.md` | User / Orchestrator | Rule changes |
 
-**Rule**: Push meta-files directly to `dev` *only* if:
-1. They don't contain feature code
-2. You've isolated the commit (it only modifies that meta-file)
-3. You use `git push origin HEAD:dev` from a clean checkout of `origin/dev`
+**Workers** create `changelogs/T-XXX.md` on their feature branch. Unique filename = zero conflicts.
+
+**Orchestrator/Planner** may push meta-file edits via their own PR or a direct push to `dev` — but only meta-files, never feature code.
 
 ---
 

--- a/.agents/workflows/feature-work.md
+++ b/.agents/workflows/feature-work.md
@@ -12,7 +12,25 @@ You must strictly follow **The Matrix Protocol**: act as Apoc, Switch, Mouse, Gh
 
 ---
 
-## ⚠️ BRANCHING RULES — READ BEFORE ANYTHING ELSE
+## ⚠️ FILE OWNERSHIP — READ BEFORE ANYTHING ELSE
+
+Workers have a **strict scope**. Touching shared meta-files causes merge conflicts across parallel agents. This table is non-negotiable.
+
+| File / Path | Worker May Edit? | Who Edits? |
+|---|---|---|
+| Feature code (`.kt`, `.xml`, `.json`) | ✅ Yes | Worker |
+| `changelogs/T-XXX.md` (create new) | ✅ Yes | Worker |
+| `.agents/TASKS.md` | ❌ **NEVER** | Orchestrator only |
+| `BACKLOG.md` | ❌ **NEVER** | Orchestrator / Planner only |
+| `CHANGELOG.md` | ❌ **NEVER** | Orchestrator at release time |
+| `PROJECT.md` | ❌ **NEVER** | Orchestrator / Oracle only |
+| `AGENT_INFO.md` / `CLAUDE.md` | ❌ **NEVER** | User / Orchestrator only |
+
+**Why:** Multiple agents run in parallel. Every shared file they all edit becomes a merge conflict. Agents that touch only their own code + a uniquely-named changelog fragment will **never** conflict with each other.
+
+---
+
+## ⚠️ BRANCHING RULES
 
 ```
 main   ← NEVER touch directly. Stable releases only.
@@ -22,8 +40,8 @@ dev    ← NEVER push feature code here directly. PRs only.
 
 - **Every feature/fix lives on its own `claude/T-XXX-*` branch.**
 - **Every branch is submitted as a PR targeting `dev`.** Never `main`.
-- **The ONLY thing you may push directly to `dev`** is the meta-file status update in Step 9 (marking the task `done` in `.agents/TASKS.md`). Nothing else.
-- If you are unsure whether something is a meta-file, **it is not — use a PR.**
+- **NEVER push anything directly to `dev`.** Not meta-files, not TASKS.md, nothing. Use PRs only.
+- If you are unsure whether you should edit a file, check the ownership table above.
 
 ---
 
@@ -48,26 +66,26 @@ dev    ← NEVER push feature code here directly. PRs only.
    git add <changed files>
    git commit -m "T-XXX: description of change"
    ```
-   Do **not** add unrelated files. Do **not** add TASKS.md here — that comes in the next step.
+   Do **not** add unrelated files. Only add files in your task scope.
 
-6. **Mark the task done — commit TASKS.md on your branch:**
-   Edit `.agents/TASKS.md` to change T-XXX status to `done`, then commit it:
-   ```bash
-   git add .agents/TASKS.md
-   git commit -m "meta: T-XXX done"
+6. **Drop a changelog fragment** — create `changelogs/T-XXX.md` with a brief summary:
    ```
-   This stays on your feature branch and merges with your PR. **Never push directly to `dev`.**
+   YYYY-MM-DD — Short Title (T-XXX)
+   - **Added/Fixed/Changed** description
+   ```
+   ```bash
+   git add changelogs/T-XXX.md
+   git commit -m "docs: T-XXX changelog fragment"
+   ```
 
-7. **Do NOT touch `CHANGELOG.md`.** The Orchestrator writes one consolidated entry after all PRs in the wave merge.
-
-8. **Rebase onto latest `dev` before pushing** to ensure a clean, conflict-free PR:
+7. **Rebase onto latest `dev` before pushing** to ensure a clean, conflict-free PR:
    ```bash
    git fetch origin dev
    git rebase origin/dev
    ```
    Resolve any conflicts, then `git rebase --continue`.
 
-9. Establish hardline (Push your branch) and upload to the Nebuchadnezzar (open a PR targeting **`dev`**):
+8. Establish hardline (Push your branch) and upload to the Nebuchadnezzar (open a PR targeting **`dev`**):
    ```bash
    git push -u origin claude/T-XXX-description
    ```
@@ -78,6 +96,8 @@ dev    ← NEVER push feature code here directly. PRs only.
    - `body`: summary of changes + `Closes T-XXX`
    - `head`: `claude/T-XXX-description`
    - `base`: `dev`   ← **always dev, never main**
+
+**That's it. You're done.** The Orchestrator handles TASKS.md, BACKLOG.md, and CHANGELOG.md after your PR merges.
 
 ---
 

--- a/.cursorrules
+++ b/.cursorrules
@@ -5,16 +5,16 @@ You are working on the **SBTracker** project. Please follow these rules to maint
 ## Core Directives
 1. **Read and display `BACKLOG.md` first**: Start every session by showing the user the current backlog to align on priorities.
 2. **Read `PROJECT.md`**: Understand the event-sourcing architecture and key invariants.
-3. **Follow Standard Workflows**: Use `.agents/workflows/feature-work.md` and `documentation-sync.md`.
-4. **Maintain Living Docs**: ALWAYS update `PROJECT.md`, `BACKLOG.md`, and `CHANGELOG.md` upon completion. Include detailed timestamps (YYYY-MM-DD HH:MM) and authorship in `CHANGELOG.md`.
-5. **Changelog Priority**: Update the changelog immediately and push directly to `dev` to avoid fragmentation from simultaneous edits.
-6. **Matrix Persona**: Address user as **Neo**. State your name at the start (e.g., "Neo, this is Morpheus"). Persona depends on your role. Incorporate Matrix terminology ("the green cascade", "jacking in", "glitches in the Matrix"). See **[The Matrix Protocol](file:///Users/a0110/AndroidStudioProjects/sbtracker/AGENT_INFO.md#the-matrix-protocol-communication-directives)**.
+3. **Follow Standard Workflows**: Use `.agents/workflows/feature-work.md` for worker tasks.
+4. **File Ownership**: Workers only edit code files and `changelogs/T-XXX.md`. Never edit `CHANGELOG.md`, `BACKLOG.md`, `TASKS.md`, or `PROJECT.md` — those are Orchestrator/Planner responsibility. See the ownership table in `feature-work.md`.
+5. **Matrix Persona**: Address user as **Neo**. State your name at the start (e.g., "Neo, this is Morpheus"). Persona depends on your role. Incorporate Matrix terminology ("the green cascade", "jacking in", "glitches in the Matrix"). See **[The Matrix Protocol](./AGENT_INFO.md#the-matrix-protocol-communication-directives)**.
 
 ## Branching & PRs
 - **Branch Prefix**: Always use `claude/` for agent work.
-- **Workflow**: Create a branch -> Implement -> Verify -> Submit Pull Request.
-- **Meta-files**: Always push updates to `BACKLOG.md`, `TASKS.md`, and agent instructions directly to `dev`. See **[Meta-file Live Sync](file:///Users/a0110/AndroidStudioProjects/sbtracker/AGENT_INFO.md#meta-file-live-sync)**.
-- **CI Verification**: Ensure the GitHub Actions build passes before merging (if applicable).
+- **Workflow**: Create a branch -> Implement -> Verify -> Submit Pull Request targeting `dev`.
+- **Never push directly to `dev` or `main`**.
+- **Git Isolation**: Always spawn worker agents with `isolation: "worktree"` to prevent branch hijacking and commit cross-contamination.
+- **CI Verification**: GitHub Actions build will verify syntax. Do not attempt local builds.
 
 ## Internal State (Brain)
 Maintain these artifacts in your session-local artifact directory:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,58 @@
+# SBTracker — Agent Quick Start
+
+> **Read this first. Then follow your role's workflow. That's it.**
+
+## Step 1: Know Your Role
+
+| Role | When | Workflow |
+|---|---|---|
+| **Worker** | You have a task ID (T-XXX) | [feature-work.md](.agents/workflows/feature-work.md) |
+| **Planner** | You need to decompose a feature | [plan-feature.md](.agents/workflows/plan-feature.md) |
+| **Orchestrator** | You need to review state & priorities | [orchestrate.md](.agents/workflows/orchestrate.md) |
+| **Oracle** | You need to audit or evaluate | [oracle.md](.agents/workflows/oracle.md) |
+| **Intake** | You have a raw feature idea | [intake.md](.agents/workflows/intake.md) |
+
+## Step 2: Know What You May Edit
+
+| File | Worker | Planner | Orchestrator |
+|---|---|---|---|
+| Code (`.kt`, `.xml`, `.json`) | ✅ | — | — |
+| `changelogs/T-XXX.md` (new) | ✅ | — | — |
+| `.agents/tasks/T-*.md` (new) | — | ✅ | — |
+| `.agents/TASKS.md` | ❌ | ❌ | ✅ |
+| `BACKLOG.md` | ❌ | ✅ | ✅ |
+| `CHANGELOG.md` | ❌ | ❌ | ✅ (release time) |
+| `PROJECT.md` | ❌ | ❌ | ✅ |
+
+**Workers:** Your PR contains only code + a `changelogs/T-XXX.md` fragment. Nothing else.
+
+## Step 3: Follow the Branch Model
+
+```
+main  ← stable releases only, never touch
+  └── dev  ← all PRs target here
+        └── claude/T-XXX-description  ← your branch
+```
+
+```bash
+git fetch origin dev
+git checkout -b claude/T-XXX-description origin/dev
+# ... work ...
+git push -u origin claude/T-XXX-description
+# → create PR targeting dev
+```
+
+## Step 4: Read Context
+
+1. Read `BACKLOG.md` — current priorities
+2. Read `PROJECT.md` — architecture (event-sourcing, key invariants)
+3. Read your task file in `.agents/tasks/T-XXX.md` — that is your complete scope
+
+## Protocol
+
+Address the user as **Neo**. State your identity at start. Follow [The Matrix Protocol](./AGENT_INFO.md#communication-protocol-the-matrix).
+
+---
+
+**Deep reference:** [AGENT_INFO.md](./AGENT_INFO.md) — personas, terminology, full protocol details
+**Build notes:** [CLAUDE.md](./CLAUDE.md) — build commands, environment quirks

--- a/AGENT_INFO.md
+++ b/AGENT_INFO.md
@@ -29,15 +29,7 @@ Each task gets its own isolated branch. That branch proposes changes to `dev` vi
    # Then create PR using mcp__github__create_pull_request with base=dev
    ```
 
-3. **Meta-files push directly to `dev` (ONLY after PR is open)**
-   ```bash
-   # Create isolated commit with JUST the meta-file change
-   git checkout -b meta-T-XXX-done origin/dev
-   # Edit .agents/TASKS.md (change status to done)
-   git add .agents/TASKS.md
-   git commit -m "meta: T-XXX done"
-   git push origin HEAD:dev  # Push only this commit to dev
-   ```
+3. **Never edit shared meta-files** — Workers do NOT edit `TASKS.md`, `BACKLOG.md`, `CHANGELOG.md`, or `PROJECT.md`. Drop a `changelogs/T-XXX.md` fragment on your feature branch instead. The Orchestrator handles the rest.
 
 4. **Always keep branches synced with `dev`**
    ```bash
@@ -53,38 +45,20 @@ Each task gets its own isolated branch. That branch proposes changes to `dev` vi
 - Changelog and TASKS.md stay in sync across parallel sessions
 - Conflicts are caught early (in PRs) not lost in direct pushes
 
-### Meta-file Live Sync (Protected)
+### Meta-file Ownership (Conflict Prevention)
 
-To ensure a "universal bucket" of information across all agents, meta-file updates must be pushed directly to `dev` **ONLY AFTER** the associated PR is open or merged.
+Shared meta-files are the #1 source of merge conflicts when agents work in parallel. **Workers must never edit these files.** Only the Orchestrator and Planner roles may edit them.
 
-**Meta-files:**
-- `BACKLOG.md`, `PROJECT.md`, `CHANGELOG.md`
-- `AGENT_INFO.md`, `CLAUDE.md`, `.cursorrules`
-- `.agents/TASKS.md`, `.agents/tasks/T-*.md`
+| File | Who May Edit | When |
+|---|---|---|
+| `.agents/TASKS.md` | Orchestrator | After PR merges (mark task `done`) |
+| `BACKLOG.md` | Orchestrator / Planner | Status sync, new item creation |
+| `CHANGELOG.md` | Orchestrator | At release time (merge fragments from `changelogs/`) |
+| `PROJECT.md` | Orchestrator / Oracle | Architecture updates |
+| `AGENT_INFO.md`, `CLAUDE.md`, `.cursorrules` | User / Orchestrator | Rule changes |
+| `.agents/tasks/T-*.md` | Planner | Task file creation |
 
-**When to push directly to `dev`:**
-1. **After a feature PR is merged**: Update `.agents/TASKS.md` to mark the task `done`
-2. **Planner work**: After creating task files, push `.agents/tasks/T-*.md` and update `BACKLOG.md`/`.agents/TASKS.md`
-3. **Orchestrator work**: Sync `BACKLOG.md` status, unblock tasks in `.agents/TASKS.md`
-
-**The Isolated Commit Workflow:**
-```bash
-git fetch origin dev
-git checkout -b meta-update-branch origin/dev
-
-# Edit the meta-file(s)
-git add [meta-files only]
-git commit -m "meta: update [description]"
-
-# Push ONLY this meta-file change to dev
-git push origin HEAD:dev
-
-# Return to feature branch (if still working)
-git checkout claude/T-XXX-name
-git branch -d meta-update-branch
-```
-
-**Critical**: Never push feature code mixed with meta-file updates. Always use a separate, clean checkout of `origin/dev`.
+**Workers** create a uniquely-named `changelogs/T-XXX.md` fragment on their feature branch. This never conflicts because each file has a unique name.
 
 ### Naming convention
 - **Prefix**: `claude/` for all agent branches
@@ -110,10 +84,9 @@ Agents are responsible for maintaining the project's "living documentation" (`PR
 
 ### Changelog Requirements
 
-You MUST **always** update `CHANGELOG.md` immediately upon completing any work, including documentation and orchestration changes. 
+**Workers:** Drop a fragment file in `changelogs/T-XXX.md` on your feature branch. Never edit `CHANGELOG.md` directly. See `changelogs/README.md` for format.
 
-- **Detailed Metadata**: Include the current timestamp (YYYY-MM-DD HH:MM), authorship (e.g., Antigravity), and origin (e.g., "Direct push to dev" or "PR to dev").
-- **Simultaneous Edits**: Be extremely diligent about this; multiple agents working in parallel cause fragmentation if the changelog isn't kept perfectly in sync. Direct syncing of meta-files to `dev` is specifically designed to mitigate this.
+**Orchestrator:** At release time, merge all fragments into `CHANGELOG.md` with detailed metadata (timestamp, authorship, origin). Then delete the fragment files.
 
 ### Internal Agent State (Brain)
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -142,6 +142,7 @@ The codebase is currently in the "Final Hardening" phase. To reach a technical A
 | 2026-03-26 | Portability strategy documented | React Native viable for future Android port. Priority: logic/data/analytics first, UI last. iOS App Store likely blocked (guideline 1.4.3). PWA not viable (background BLE). See `PROJECT.md` — Future Platforms section. |
 | 2026-03-26 | F-018b: capsule weight is a global setting, not a per-session variable | Users do not meaningfully vary pack weight session to session. The binary isCapsule flag is the meaningful annotation. Per-session weight override UI will not be built; `SessionMetadata.capsuleWeightGrams` field exists in schema but its UI path remains closed. Weight is always resolved from global preferences at query time. |
 | 2026-03-26 | F-018b: Health tab requires day-level intake granularity, not period averages | 7-day and 30-day trailing averages are too coarse — they hide the patterns that matter (which days are heavy, whether trend is up or down). `DailyStats` must gain `totalGramsConsumed` for charting. Default chart view must show ≥14 days. `gramsPerDay7d`/`gramsPerDay30d` can remain as summary figures only. |
+| 2026-03-26 | Agent rule consolidation — eliminate merge conflicts | Workers may ONLY edit code files and `changelogs/T-XXX.md` fragments. TASKS.md, BACKLOG.md, CHANGELOG.md and PROJECT.md are Orchestrator/Planner owned. Rules unified across `CLAUDE.md`, `.cursorrules`, `AGENT_INFO.md`, `feature-work.md`, `WORKFLOW_ENFORCEMENT.md`, and `PROJECT.md`. |
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,16 +18,17 @@ Requires JDK 21. The CI workflow mirrors these commands.
 
 **⚠️ AGENTS: Debug build FAILS in this environment** (Gradle plugin resolution blocked by proxy). **IGNORE BUILD FAILURES.** Skip `./gradlew assembleDebug` entirely. Code syntax validation is sufficient. CI will handle real builds.
 
-Drop a fragment in `changelogs/` — one file per PR, named after your task ID or branch slug.
+## Changelog Rule
 
-**Format** (`changelogs/T-XXX.md` or `changelogs/YYYY-MM-DD_slug.md`):
+**Never edit `CHANGELOG.md` directly.** Drop a fragment in `changelogs/T-XXX.md` — one file per PR, named after your task ID.
+
+**Format** (`changelogs/T-XXX.md`):
 ```
 YYYY-MM-DD — Short Title (T-XXX)
 - **Added/Fixed/Changed/Improved** description
 ```
 
-**Never edit `CHANGELOG.md` directly.** It is the historical release record. The Orchestrator merges fragments into it at release time. See `changelogs/README.md`.
-
+The Orchestrator merges fragments into `CHANGELOG.md` at release time. See `changelogs/README.md`.
 
 # Agent Rules & Guidelines
 
@@ -36,15 +37,14 @@ You are working on the **SBTracker** project. Please follow these rules to maint
 ## Core Directives
 1. **Read and display `BACKLOG.md` first**: Start every session by showing the user the current backlog to align on priorities.
 2. **Read `PROJECT.md`**: Understand the event-sourcing architecture and key invariants.
-3. **Follow Standard Workflows**: Use `.agents/workflows/feature-work.md` and `.agents/workflows/documentation-sync.md`.
-4. **Maintain Living Docs**: Always update `PROJECT.md`, `BACKLOG.md`, and `CHANGELOG.md` upon completion.
+3. **Follow Standard Workflows**: Use `.agents/workflows/feature-work.md` for worker tasks.
+4. **File Ownership**: Workers only edit code files and `changelogs/T-XXX.md`. Never edit `CHANGELOG.md`, `BACKLOG.md`, `TASKS.md`, or `PROJECT.md` — those are Orchestrator/Planner responsibility. See the ownership table in `feature-work.md`.
 5. **Matrix Persona**: Address user as **Neo**. State your name at the start (e.g., "Neo, this is Morpheus"). Persona depends on your role. Incorporate Matrix terminology ("the green cascade", "jacking in", "glitches in the Matrix"). See **[The Matrix Protocol](./AGENT_INFO.md#the-matrix-protocol-communication-directives)**.
 
 ## Branching & PRs
 - **Branch Prefix**: Always use `claude/` for agent work.
-- **Workflow**: Create a branch -> Implement -> Verify -> Submit Pull Request.
-- **Meta-files**: Meta status updates (e.g., `.agents/TASKS.md` marking task `done`) go IN the PR branch as a final commit, NOT as a separate direct push to `dev`.
-- **Changelog**: Drop a fragment in `changelogs/` per PR. Never edit `CHANGELOG.md` directly.
+- **Workflow**: Create a branch -> Implement -> Verify -> Submit Pull Request targeting `dev`.
+- **Never push directly to `dev` or `main`**.
 - **Git Isolation**: Always spawn worker agents with `isolation: "worktree"` to prevent branch hijacking and commit cross-contamination.
 - **CI Verification**: GitHub Actions build will verify syntax. Do not attempt local builds.
 

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -205,13 +205,12 @@ The architecture is intentionally split to maximise portability:
 3. **Never store derived data** in the DB — compute from `device_status`.
 4. **Never skip schema versions** — always increment by 1.
 5. **Keep `fallbackToDestructiveMigration()`** during development (removed in T-016).
-6. **Update `BACKLOG.md`** when starting and completing work.
-7. **Drop a fragment in `changelogs/`** — one `.md` file per PR, named after your task or branch slug. Never edit `CHANGELOG.md` directly. See `changelogs/README.md`.
-8. **Mark tasks done in `.agents/TASKS.md`** when complete.
-9. **Use agent branches** — `claude/T-XXX-description` for task work.
-10. **Follow PR-based workflow** — create a branch, implement, verify, submit PR. Never commit directly to `main`.
-11. **Verify build** — `./gradlew assembleDebug` must pass before pushing.
-12. **Reference app** in `!gitignore.referenceonly-reactive-volcano-app-main/` is for protocol reference only — do not modify.
+6. **Drop a changelog fragment** — create `changelogs/T-XXX.md` on your feature branch. Never edit `CHANGELOG.md` directly.
+7. **Do NOT edit `TASKS.md`, `BACKLOG.md`, or `CHANGELOG.md`** — that's the Orchestrator's job after your PR merges.
+8. **Use agent branches** — `claude/T-XXX-description` for task work.
+9. **Follow PR-based workflow** — create a branch, implement, verify, submit PR. Never commit directly to `main`.
+10. **Verify build** — `./gradlew assembleDebug` must pass before pushing.
+11. **Reference app** in `!gitignore.referenceonly-reactive-volcano-app-main/` is for protocol reference only — do not modify.
 
 ---
 


### PR DESCRIPTION
## Summary

Oracle analysis identified that **every agent PR conflicts with every other PR** because 4 instruction files gave contradictory rules about editing shared meta-files (TASKS.md, CHANGELOG.md, BACKLOG.md).

## The Fix

**One new rule:** Workers may ONLY edit code files and `changelogs/T-XXX.md` fragments. Everything else is Orchestrator/Planner owned.

### Files Changed (8)

| File | Change |
|---|---|
| `AGENTS.md` | **NEW** — concise entry-point with role routing and file ownership table |
| `feature-work.md` | Added ownership table, removed TASKS.md edit step, added changelog fragment step |
| `AGENT_INFO.md` | Replaced meta-file direct-push rules with ownership table |
| `CLAUDE.md` | Rewritten — enforces fragment-only changelog, no meta-file editing |
| `.cursorrules` | Now mirrors CLAUDE.md exactly |
| `WORKFLOW_ENFORCEMENT.md` | Aligned meta-file section with new ownership model |
| `PROJECT.md` | Updated rules section, renumbered |
| `BACKLOG.md` | Decisions log entry added |

### Contradictions Resolved

- `AGENT_INFO.md` said "always update CHANGELOG.md" — `CLAUDE.md` said "never edit CHANGELOG.md"
- `feature-work.md` said "commit TASKS.md on your branch" — caused conflict on every parallel PR
- `.cursorrules` said "push meta-files directly to dev" — `feature-work.md` said "never push to dev"

All four files now agree: workers touch code + changelog fragments only.